### PR TITLE
Replace removed readr::read_table2 with read_table (fixes #99)

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -28,8 +28,8 @@ packedancestrymap_to_afs = function(pref, inds = NULL, pops = NULL, adjust_pseud
 
   pref %<>% normalizePath(mustWork = FALSE)
   nam = c('SNP', 'CHR', 'cm', 'POS', 'A1', 'A2')
-  indfile = read_table2(paste0(pref, '.ind'), col_names = FALSE, col_types = 'ccc', progress = FALSE)
-  snpfile = read_table2(paste0(pref, '.snp'), col_names = nam, col_types = 'ccddcc', progress = FALSE)
+  indfile = read_table(paste0(pref, '.ind'), col_names = FALSE, col_types = 'ccc', progress = FALSE)
+  snpfile = read_table(paste0(pref, '.snp'), col_names = nam, col_types = 'ccddcc', progress = FALSE)
   nindall = nrow(indfile)
   nsnpall = as.numeric(nrow(snpfile))
   first = max(1, first)
@@ -76,8 +76,8 @@ eigenstrat_to_afs_old = function(pref, inds = NULL, pops = NULL, adjust_pseudoha
   if(verbose) alert_info('Reading allele frequencies from EIGENSTRAT files...\n')
 
   nam = c('SNP', 'CHR', 'cm', 'POS', 'A1', 'A2')
-  indfile = read_table2(paste0(pref, '.ind'), col_names = FALSE, col_types = 'ccc', progress = FALSE)
-  snpfile = read_table2(paste0(pref, '.snp'), col_names = nam, col_types = 'ccddcc', progress = FALSE)
+  indfile = read_table(paste0(pref, '.ind'), col_names = FALSE, col_types = 'ccc', progress = FALSE)
+  snpfile = read_table(paste0(pref, '.snp'), col_names = nam, col_types = 'ccddcc', progress = FALSE)
 
   ip = match_samples(indfile$X1, indfile$X3, inds, pops)
   indvec = ip$indvec
@@ -136,8 +136,8 @@ eigenstrat_to_afs = function(pref, inds = NULL, pops = NULL, numparts = 100,
   if(verbose) alert_info('Reading allele frequencies from EIGENSTRAT files...\n')
 
   nam = c('SNP', 'CHR', 'cm', 'POS', 'A1', 'A2')
-  indfile = read_table2(paste0(pref, '.ind'), col_names = FALSE, col_types = 'ccc', progress = FALSE)
-  snpfile = read_table2(paste0(pref, '.snp'), col_names = nam, col_types = 'ccddcc', progress = FALSE)
+  indfile = read_table(paste0(pref, '.ind'), col_names = FALSE, col_types = 'ccc', progress = FALSE)
+  snpfile = read_table(paste0(pref, '.snp'), col_names = nam, col_types = 'ccddcc', progress = FALSE)
 
   ip = match_samples(indfile$X1, indfile$X3, inds, pops)
   indvec = ip$indvec
@@ -334,8 +334,8 @@ read_packedancestrymap = function(pref, inds = NULL, pops = NULL, first = 1, las
 
   pref = normalizePath(pref, mustWork = FALSE)
   nam = c('SNP', 'CHR', 'cm', 'POS', 'A1', 'A2')
-  indfile = read_table2(paste0(pref, '.ind'), col_names = FALSE, col_types = 'ccc', progress = FALSE)
-  snpfile = read_table2(paste0(pref, '.snp'), col_names = nam, col_types = 'ccddcc', skip = first-1,
+  indfile = read_table(paste0(pref, '.ind'), col_names = FALSE, col_types = 'ccc', progress = FALSE)
+  snpfile = read_table(paste0(pref, '.snp'), col_names = nam, col_types = 'ccddcc', skip = first-1,
                         n_max = last-first+1, progress = FALSE)
   if(!is.null(pops)) {
     if(!is.null(inds)) stop("'inds' and 'pops' cannot both be provided!")
@@ -510,8 +510,8 @@ plink_to_afs = function(pref, inds = NULL, pops = NULL, adjust_pseudohaploid = T
   famfile = paste0(pref, '.fam')
   bimfile = paste0(pref, '.bim')
   nam = c('CHR', 'SNP', 'cm', 'POS', 'A1', 'A2')
-  bim = read_table2(bimfile, col_names = nam, progress = FALSE, col_types = 'ccddcc')
-  fam = read_table2(famfile, col_names = FALSE, progress = FALSE, col_types = 'cccccc')
+  bim = read_table(bimfile, col_names = nam, progress = FALSE, col_types = 'ccddcc')
+  fam = read_table(famfile, col_names = FALSE, progress = FALSE, col_types = 'cccccc')
   nsnpall = nrow(bim)
   nindall = nrow(fam)
   first = max(0, first)
@@ -646,8 +646,8 @@ read_plink = function(pref, inds = NULL, pops = NULL, verbose = FALSE) {
   famfile = paste0(pref, '.fam')
   bimfile = paste0(pref, '.bim')
   nam = c('CHR', 'SNP', 'cm', 'POS', 'A1', 'A2')
-  bim = read_table2(bimfile, col_names = nam, col_types = 'ccddcc', progress = FALSE)
-  fam = read_table2(famfile, col_names = FALSE, col_types = 'cccccc', progress = FALSE)
+  bim = read_table(bimfile, col_names = nam, col_types = 'ccddcc', progress = FALSE)
+  fam = read_table(famfile, col_names = FALSE, col_types = 'cccccc', progress = FALSE)
 
   if(!is.null(pops)) {
     if(!is.null(inds)) stop("'inds' and 'pops' cannot both be provided!")
@@ -907,8 +907,8 @@ afs_to_f2 = function(afdir, outdir, chunk1, chunk2, blgsize = 0.05, snpwt = NULL
 
   if(is.null(snpdat)) {
     fl = paste0(afdir, '/snpdat.tsv.gz')
-    nc = ncol(read_table2(fl, n_max = 0, col_types=cols()))
-    snpdat = read_table2(fl, col_types = paste0('ccddcc', paste0(rep('?', nc-6), collapse='')), progress = FALSE)
+    nc = ncol(read_table(fl, n_max = 0, col_types=cols()))
+    snpdat = read_table(fl, col_types = paste0('ccddcc', paste0(rep('?', nc-6), collapse='')), progress = FALSE)
   }
 
   am1 = readRDS(paste0(afdir, '/afs', chunk1, '.rds'))
@@ -1097,7 +1097,7 @@ extract_f2 = function(pref, outdir, inds = NULL, pops = NULL, blgsize = 0.05, ma
     warning("Most `extract_f2` options will be ignored when using the `qpfstats` option!")
     if(is.null(pops)) {
       fi = format_info(pref)
-      pops = unique(read_table2(paste0(pref, fi$indend), col_names=F, col_types = fi$indtype)[[which(fi$indnam == 'pop')]])
+      pops = unique(read_table(paste0(pref, fi$indend), col_names=F, col_types = fi$indtype)[[which(fi$indnam == 'pop')]])
     }
     f2blocks = qpfstats(pref, pops, ...)
     if(is.null(outdir)) {
@@ -1380,7 +1380,7 @@ extract_counts_large = function(pref, outdir, inds = NULL, blgsize = 0.05, cols_
   # same as extract_counts, but split across chunks of individuals
   pref %<>% normalizePath(mustWork = FALSE)
   l = format_info(pref, format)
-  indfile = read_table2(paste0(pref, l$indend), col_names = l$indnam, col_types = l$indtype, progress = FALSE)
+  indfile = read_table(paste0(pref, l$indend), col_names = l$indnam, col_types = l$indtype, progress = FALSE)
   if(!is.null(inds)) indfile %<>% filter(ind %in% inds)
 
   snpdat = extract_afs(pref, outdir, inds = indfile$ind, pops = indfile$ind, cols_per_chunk = cols_per_chunk, numparts = 100,
@@ -1516,8 +1516,8 @@ extract_afs = function(pref, outdir, inds = NULL, pops = NULL, cols_per_chunk = 
   l = format_info(pref, format)
 
   if(verbose) alert_info(paste0('Reading metadata...\n'))
-  indfile = read_table2(paste0(pref, l$indend), col_names = l$indnam, col_types = l$indtype, progress = FALSE)
-  snpfile = read_table2(paste0(pref, l$snpend), col_names = l$snpnam, col_types = 'ccddcc', progress = FALSE)
+  indfile = read_table(paste0(pref, l$indend), col_names = l$indnam, col_types = l$indtype, progress = FALSE)
+  snpfile = read_table(paste0(pref, l$snpend), col_names = l$snpnam, col_types = 'ccddcc', progress = FALSE)
   nindall = nrow(indfile)
   nsnpall = nrow(snpfile)
 
@@ -2134,7 +2134,7 @@ packedancestrymap_to_plink = function(inpref, outpref, inds = NULL, pops = NULL,
   if(system.file(package = 'genio') == '') stop('Please install the "genio" package!')
   inpref = normalizePath(inpref, mustWork = F)
   if(!is.null(pops)) {
-    inds = read_table2(paste0(inpref, '.ind'), col_names = F, col_types = 'ccc') %>%
+    inds = read_table(paste0(inpref, '.ind'), col_names = F, col_types = 'ccc') %>%
       filter(X3 %in% pops) %$% X1
   }
 
@@ -2168,7 +2168,7 @@ extract_samples = function(inpref, outpref, inds = NULL, pops = NULL, overwrite 
   if(inpref == outpref && !overwrite)
     stop("If you really want to overwrite the input files, set 'overwrite = TRUE'")
   if(!is.null(pops)) {
-    inds = read_table2(paste0(inpref, '.fam'), col_names = F, col_types = 'cccccc') %>%
+    inds = read_table(paste0(inpref, '.fam'), col_names = F, col_types = 'cccccc') %>%
       filter(X1 %in% pops) %$% X2
   }
   dat = read_plink(inpref, inds, verbose = verbose)
@@ -2238,8 +2238,8 @@ f4blockdat_from_geno = function(pref, popcombs = NULL, left = NULL, right = NULL
   pref = normalizePath(pref, mustWork = FALSE)
   l = format_info(pref)
 
-  indfile = read_table2(paste0(pref, l$indend), col_names = l$indnam, col_types = l$indtype, progress = FALSE)
-  snpfile = read_table2(paste0(pref, l$snpend), col_names = l$snpnam, col_types = 'ccddcc', progress = FALSE)
+  indfile = read_table(paste0(pref, l$indend), col_names = l$indnam, col_types = l$indtype, progress = FALSE)
+  snpfile = read_table(paste0(pref, l$snpend), col_names = l$snpnam, col_types = 'ccddcc', progress = FALSE)
   cpp_read_geno = l$cpp_read_geno
   fl = paste0(pref, l$genoend)
 
@@ -2369,8 +2369,8 @@ f3blockdat_from_geno = function(pref, popcombs, auto_only = TRUE,
   pref = normalizePath(pref, mustWork = FALSE)
   l = format_info(pref)
 
-  indfile = read_table2(paste0(pref, l$indend), col_names = l$indnam, col_types = l$indtype, progress = FALSE)
-  snpfile = read_table2(paste0(pref, l$snpend), col_names = l$snpnam, col_types = 'ccddcc', progress = FALSE)
+  indfile = read_table(paste0(pref, l$indend), col_names = l$indnam, col_types = l$indtype, progress = FALSE)
+  snpfile = read_table(paste0(pref, l$snpend), col_names = l$snpnam, col_types = 'ccddcc', progress = FALSE)
   cpp_read_geno = l$cpp_read_geno
   fl = paste0(pref, l$genoend)
 

--- a/R/qpdstat.R
+++ b/R/qpdstat.R
@@ -356,7 +356,7 @@ fstat_get_popcombs = function(f2_data = NULL, pop1 = NULL, pop2 = NULL, pop3 = N
   #     indend = '.fam'
   #     popcol = 1
   #   }
-  #   pop1 = read_table2(paste0(f2_data, indend), col_types = cols(), col_names = FALSE, progress = FALSE)[[popcol]]
+  #   pop1 = read_table(paste0(f2_data, indend), col_types = cols(), col_names = FALSE, progress = FALSE)[[popcol]]
   # }
   if(!is.null(pop2)) {
     ncomb = length(pop1) * length(pop2) * max(1, length(pop3)) * max(1, length(pop4))
@@ -367,11 +367,11 @@ fstat_get_popcombs = function(f2_data = NULL, pop1 = NULL, pop2 = NULL, pop3 = N
     out = expand_grid(pop1, pop2, pop3, pop4)
   } else if(is.null(pop1)) {
     if(is_precomp_dir(f2_data)) pop1 = list.dirs(f2_data, full.names=FALSE, recursive=FALSE)
-    else if(is_plink_prefix(f2_data)) pop1 = unique(read_table2(paste0(f2_data,'.fam'), col_names=F, col_types = cols())$X1)
-    else if(is_ancestrymap_prefix(f2_data)) pop1 = unique(read_table2(paste0(f2_data,'.ind'), col_names=F, col_types = cols())$X3)
+    else if(is_plink_prefix(f2_data)) pop1 = unique(read_table(paste0(f2_data,'.fam'), col_names=F, col_types = cols())$X1)
+    else if(is_ancestrymap_prefix(f2_data)) pop1 = unique(read_table(paste0(f2_data,'.ind'), col_names=F, col_types = cols())$X3)
     else pop1 = dimnames(f2_data)[[1]]
   } else if(is.character(pop1)[1] && file.exists(pop1[1])) {
-    pop1 = read_table2(pop1, col_names = FALSE)
+    pop1 = read_table(pop1, col_names = FALSE)
     if(ncol(pop1) == 1) {
       pop1 = pop1[[1]]
     } else {

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -143,7 +143,7 @@ qpdstat_wrapper = function(pref, pop1, pop2 = NULL, pop3 = NULL, pop4 = NULL,
       pop1 %>% select(1:4) %>% write_tsv(popfilename, col_names = FALSE)
     } else if(length(pop1) == 1) {
       stopifnot(file.exists(pop1))
-      dat = read_table2(pop1, col_names = FALSE)
+      dat = read_table(pop1, col_names = FALSE)
       if(ncol(dat) < 4) popfiletype = 'poplistname'
       popfilename = pop1
     } else {
@@ -764,7 +764,7 @@ parse_qpgraph_parfile = function(parfile) {
   # returns named list of parameters
   # all genotype files have to have same prefix
 
-  dat = read_table2(parfile, comment = '#', col_names = c('par', 'value'), col_types = cols())
+  dat = read_table(parfile, comment = '#', col_names = c('par', 'value'), col_types = cols())
   dat %<>% mutate(par = str_replace_all(par, c(':$'='', 'genotypename'='pref')),
                   value = str_replace_all(value,
                                           c('\\.geno$'='',
@@ -791,7 +791,7 @@ parse_qpdstat_parfile = function(parfile) {
   # returns named list of parameters
   # all genotype files have to have same prefix
 
-  dat = read_table2(parfile, comment = '#', col_names = c('par', 'value'), col_types = cols())
+  dat = read_table(parfile, comment = '#', col_names = c('par', 'value'), col_types = cols())
   dat %>% mutate(par = str_replace_all(par, c(':$'='', 'genotypename'='pref')),
                  value = str_replace_all(value,
                                          c('\\.geno$'='',
@@ -1558,7 +1558,7 @@ f2_from_msprime = function(..., blgsize = 0.05, cleanup = TRUE, verbose = TRUE) 
 
 plot_ellout = function(evecfile, ellfile) {
 
-  evec = read_table2(evecfile, col_names = FALSE, skip = 1) %>%
+  evec = read_table(evecfile, col_names = FALSE, skip = 1) %>%
     transmute(id = X1, pop = X4, x = X2, y = X3)
   dd = read_lines(ellfile)
   samples = dd %>% str_subset('^sample:') %>% str_squish %>% word(2)
@@ -1606,9 +1606,9 @@ parse_treemix_treeout = function(treeout) {
 
 parse_treemix = function(stem, split = FALSE) {
 
-  vert = read_table2(paste0(stem, '.vertices.gz'), col_names = FALSE, col_types = cols(.default = 'c')) %>%
+  vert = read_table(paste0(stem, '.vertices.gz'), col_names = FALSE, col_types = cols(.default = 'c')) %>%
     transmute(num = X1, nam = ifelse(is.na(X2), paste0('n',num), X2)) %>% deframe
-  edges = read_table2(paste0(stem, '.edges.gz'), col_names = FALSE, col_types = cols(.default = 'c')) %>%
+  edges = read_table(paste0(stem, '.edges.gz'), col_names = FALSE, col_types = cols(.default = 'c')) %>%
     transmute(from = vert[X1], to = vert[X2])
   if(split) edges %<>% as.matrix %>% split_multifurcations %>% select(1:2)
   edges %>% as.matrix %>% graph_from_edgelist()

--- a/inst/shiny_admixtools/app.R
+++ b/inst/shiny_admixtools/app.R
@@ -581,7 +581,7 @@ server = function(input, output, session) {
 
   observeEvent(input$popfile, {
 
-    inddat = read_table2(input$popfile$datapath, col_names = FALSE, col_types = cols())
+    inddat = read_table(input$popfile$datapath, col_names = FALSE, col_types = cols())
     if(ncol(inddat) == 3) colnames(inddat) = c('ind', 'sex', 'pop')
     else if(ncol(inddat) == 6) colnames(inddat) = c('pop', 'ind', 'p1', 'p2', 'sex', 'pheno')
     else shinyalert('Error', paste0('sample file has ',ncol(inddat),' columns!'))
@@ -646,7 +646,7 @@ server = function(input, output, session) {
       global$graph = parse_qpgraph_graphfile(gf) %>% graph_from_edgelist()
     } else {
       print('two column format')
-      global$graph = read_table2(gf, col_types = cols()) %>% select(1:2) %>%
+      global$graph = read_table(gf, col_types = cols()) %>% select(1:2) %>%
         as.matrix %>% graph_from_edgelist()
     }
     print('read graphfile done')

--- a/vignettes/graphs.Rmd
+++ b/vignettes/graphs.Rmd
@@ -394,7 +394,7 @@ plotly_graph(newgraph)
 ```
 
 
-To load an existing graph, use `parse_qpgraph_graphfile()` if it's in the original *ADMIXTOOLS* format, `read_table2()` if it's an edge list, or `readRDS()` if it was saved in R using `saveRDS()`.
+To load an existing graph, use `parse_qpgraph_graphfile()` if it's in the original *ADMIXTOOLS* format, `read_table()` if it's an edge list, or `readRDS()` if it was saved in R using `saveRDS()`.
 
 
 

--- a/vignettes/io.Rmd
+++ b/vignettes/io.Rmd
@@ -170,7 +170,7 @@ admix  D
 We can save this in a text file `graph.txt` and read it into R like this:
 
 ```{r, eval = FALSE}
-graph_el = read_table2('~/Downloads/graph.tsv', col_names = F)
+graph_el = read_table('~/Downloads/graph.tsv', col_names = F)
 plotly_graph(graph_el)
 ```
 ```{r, echo = FALSE}


### PR DESCRIPTION
## Summary

- readr 2.0 (2021) deprecated `read_table2`; subsequent readr versions removed it from the namespace. admixtools fails to install or run against modern readr because of unqualified `read_table2` calls in 38 locations. Per the readr 2.0 release notes, `read_table` is a drop-in replacement for `read_table2`, so this is a pure name swap with no behavior change.
- Scope: `R/io.R` (24), `R/wrappers.R` (6), `R/qpdstat.R` (4), `inst/shiny_admixtools/app.R` (2), `vignettes/io.Rmd` (1), `vignettes/graphs.Rmd` (1). Auto-generated `docs/articles/*.html` left untouched (pkgdown regenerates at release time).
- Fixes #99.

## Test plan

- [x] `R CMD INSTALL .` succeeds against readr 2.2.0
- [x] Package loads with readr 2.2.0 (where `read_table2` is no longer exported)
- [x] Zero functions in the admixtools namespace still reference `read_table2`; 22 now reference `read_table`
- [x] `parse_qpgraph_parfile()` reads a sample parfile end-to-end and returns the expected named list
- [x] Real-data check: Patterson 2021 `brit.ind` (826 rows × 3 cols) parses identically with `read_table`
- [x] All five argument patterns admixtools uses (`col_names = FALSE`, `col_names = c(...)`, `col_types = "..."`, `comment = '#'`, `n_max = 0`, `skip = 1`) verified equivalent on minimal inputs