### PR TITLE
Wrap get.edge.ids 2nd arg with igraph::as_ids() to fix igraph 2.1.4+ vertex-sequence rejection (fixes #94)

### DIFF
--- a/R/qpgraph.R
+++ b/R/qpgraph.R
@@ -18,7 +18,7 @@ graph_to_pwts = function(graph, leaves) {
     target = names(tail(allpaths[[i]],1))
     ln = length(allpaths[[i]])
     pth2 = allpaths[[i]][c(1, 1+rep(seq_len(ln-2), each=2), ln)]
-    rowind = as.vector(E(graph)[get.edge.ids(graph, pth2)])
+    rowind = as.vector(E(graph)[get.edge.ids(graph, igraph::as_ids(pth2))])
     pwts[rowind,target] = pwts[rowind,target] + 1/pathcounts[target]
   }
 
@@ -71,7 +71,7 @@ graph_to_weightind = function(graph) {
   normedges = setdiff(1:length(E(graph)), admixedges)
   paths = all_simple_paths(graph, root, leaves, mode='out')
   ends = sapply(paths, tail, 1)
-  edge_per_path = paths %>% map(expand_path) %>% map(~get.edge.ids(graph, .))
+  edge_per_path = paths %>% map(expand_path) %>% map(~get.edge.ids(graph, igraph::as_ids(.)))
   weight_per_path = edge_per_path %>% map(~(which(admixedges %in% .)))
 
   path_edge_table = do.call(rbind, lapply(seq_len(length(weight_per_path)),


### PR DESCRIPTION
## Summary

- igraph 2.1.4+ tightened `get.edge.ids()` to require its `vp` argument to be one of: a two-column data.frame, a two-column matrix, or a plain vector. Vertex sequences (`igraph.vs`) were silently accepted under the old API but now raise `Only two-column data.frames and matrices, and vectors are allowed for vp`.
- `graph_to_pwts()` and `graph_to_weightind()` in `R/qpgraph.R` (the only two call sites) both pass an `igraph.vs` produced by indexing into `all_simple_paths()` output. So calls like `qpgraph(example_f2_blocks, example_graph)` (the one from the issue) fail unconditionally under current igraph.
- This PR wraps the second argument with `igraph::as_ids()` at both call sites. `as_ids()` returns an integer vector of vertex IDs (or character names if the graph is named) — both shapes are accepted by the new API. On a plain vector it's a no-op, so the wrap is safe even if a future call site passes a non-sequence.
- Fixes #94.

## Test plan

- [x] **Bug reproduces pre-fix** with admixtools 2.0.10 + igraph 2.3.1: `qpgraph(example_f2_blocks, example_graph)` errors with the exact message from the issue
- [x] **Bug fixed post-fix** with same versions: `qpgraph(example_f2_blocks, example_graph)` returns the expected fitted graph object (`list` with `edges`, `score`, `f3`, `opt`, `ppinv`; score = 19220)
- [x] Diff is minimal — 1 file, +2/-2 lines

## Notes

- @krlmlr suggested converting to a matrix or data.frame in the issue thread; `as_ids()` is the equivalent fix using igraph's own helper, and the result (an atomic vector) is among the shapes the tightened API accepts.
- @krlmlr also noted `get.edge.ids()` is deprecated in favor of `get_edge_ids()`. I deliberately left the call name untouched to keep this PR scoped to the failing-call fix; renaming to silence the deprecation warning is a separate, larger change touching `@importFrom` declarations and could be a follow-up if you'd like.
- This is the third in a small series of compatibility PRs (the other two are #101 readr and #102 RcppArmadillo). All three are independently scoped against existing open issues.