### PR TITLE
Replace ifelse with dplyr::if_else at find_graphs mutfun site (fixes #104)

### DIFF
--- a/R/toposearch.R
+++ b/R/toposearch.R
@@ -2776,7 +2776,7 @@ find_graphs = function(data, numadmix = 0, outpop = NULL, stop_gen = 100, stop_g
         newmod = tibble()
       } else {
         newmod = e %>% slice_min(weight, n = floor(numgraphs/2)) %>%
-          mutate(mutfun = ifelse(type == 'admix', sample(names(wfuns), 1), sample(names(dfuns), 1)),
+          mutate(mutfun = dplyr::if_else(type == 'admix', sample(names(wfuns), 1), sample(names(dfuns), 1)),
                  fun = allfuns[mutfun],
                  g = pmap(list(fun, from, to), function(x, y, z) possibly(x, NULL)(graph, y, z))) %>%
           rowwise %>% filter(!is.null(g)) %>% ungroup


### PR DESCRIPTION
## Summary

- Base R's `ifelse(logical(0), "a", "b")` returns `logical(0)`, regardless of the yes/no arg types. `dplyr::if_else` returns `character(0)` (correctly preserving the yes/no type) on the same input. This PR swaps the former for the latter at one specific call site in `R/toposearch.R` where the test vector can be empty by argument choice.
- The site is `find_graphs()`'s `newmod = e %>% slice_min(weight, n = floor(numgraphs/2)) %>% mutate(mutfun = ifelse(...))`. With `numgraphs = 1` (the natural setting for parallel random-start runs), `slice_min(weight, n = 0)` returns 0 rows, `ifelse` runs on an empty test, and `newmod$mutfun` becomes `logical(0)` instead of `character(0)`. That column type propagates through the subsequent mutate/pmap/rowwise/filter chain and breaks `newmod %<>% bind_rows(newswap)` at line 2789 under dplyr 1.1+ vctrs type strictness:

  ```
  Can't combine `..1$mutfun` <logical> and `..2$mutfun` <character>.
  ```

- One-token substitution. No behavior change on non-empty input. `DESCRIPTION` already declares `dplyr (>= 1.1.0)` so `if_else` is guaranteed available.
- Fixes #104.

## Test plan

- [x] **Bug reproduces pre-fix** with admixtools 2.0.10 + dplyr 1.2.1 + vctrs 0.7.3:
  ```r
  set.seed(1007)
  find_graphs(example_f2_blocks, numgraphs = 1, numadmix = 2, stop_gen = 50,
              outpop = "Chimp.REF", verbose = FALSE)
  # Error: Can't combine `..1$mutfun` <logical> and `..2$mutfun` <character>.
  ```
- [x] **Bug fixed post-fix** (with #94's igraph fix also applied — see note below): same call returns a 34-row tibble of graph models.
- [x] Diff is minimal: 1 file, +1/-1.

## Note on test interaction with #94

On vanilla master, applying *just* this PR lets `find_graphs` get past the bind_rows site fixed here, but then immediately hits the igraph 2.1.4+ `get.edge.ids` vertex-sequence rejection — that's the separate bug tracked as #94 and addressed in #103. The two fixes are completely independent of each other; either can land first. End-to-end success of the seed-1007 reproducer requires both.

## Notes

- Other `ifelse(...)` calls in `R/toposearch.R` operate on non-empty vectors by construction and don't have this bug — only the line-2779 site is on a slice that can be empty by argument choice.
- This is the fourth in a series of small compatibility PRs against existing open issues (#101 readr, #102 RcppArmadillo, #103 igraph, #104 dplyr).