### PR TITLE
add matrix_jackknife_est: vectorized popcomb-level jackknife and qpfstats matrices path

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -3119,7 +3119,8 @@ f4blockdat_from_geno = function(pref, popcombs = NULL, left = NULL, right = NULL
                                 blgsize = 0.05,
                                 block_lengths = NULL, f4mode = TRUE, allsnps = FALSE,
                                 poly_only = FALSE, snpwt = NULL, keepsnps = NULL,
-                                cm_file = NULL, verbose = TRUE) {
+                                cm_file = NULL, verbose = TRUE,
+                                return_matrices = FALSE) {
 
   stopifnot(!is.null(popcombs) || (!is.null(left) && !is.null(right)))
   stopifnot(is.null(popcombs) || is.null(left) && is.null(right))
@@ -3372,6 +3373,25 @@ f4blockdat_from_geno = function(pref, popcombs = NULL, left = NULL, right = NULL
   }
   if(verbose) cat('\n')
 
+  if(return_matrices) {
+    # Skip the long-format expand_grid build below. At dense f4 scales
+    # (e.g. 1.5M popcombs * ~1300 blocks = 2 billion rows) expand_grid
+    # materializes a tibble that peaks at hundreds of GB and is a hard
+    # ceiling on the workload. Callers like qpfstats that consume the
+    # result as matrices anyway can request the underlying matrices
+    # directly via return_matrices = TRUE; this early-return fires
+    # BEFORE expand_grid so the long-format frame is never built.
+    return(list(
+      numer    = numer,
+      cnt      = cnt,
+      denom    = if(f4mode) NULL else denom,
+      popcombs = pc,
+      block_lengths = block_lengths,
+      f4mode   = f4mode,
+      hasmodels = hasmodels
+    ))
+  }
+
   out = pc %>%
     expand_grid(block = 1:numblocks) %>%
     mutate(est = c(numer), n = c(cnt))
@@ -3613,25 +3633,43 @@ qpfstats = function(pref, pops, include_f2 = TRUE, include_f3 = TRUE, include_f4
     if(is.numeric(include_f4)) pcf4 %<>% slice_sample(n = include_f4)
     popcomb %<>% bind_rows(pcf4)
   }
-  f4blockdat = f4blockdat_from_geno(pref, popcomb, allsnps = TRUE)
-  f4pass1 = f4blockdat %>% f4blockdat_to_f4out(FALSE)
+
+  # Request matrices directly from f4blockdat_from_geno instead of the
+  # long-format frame. Two costs in the long-format path:
+  #
+  #  1) building it: expand_grid(popcomb, block = 1:numblocks) materializes
+  #     a tibble with npopcomb * nblocks rows. At dense f4 scales (e.g.
+  #     1.5M popcombs * ~1300 blocks = 2 billion rows) this peaks at
+  #     hundreds of GB and is a hard ceiling on the workload.
+  #
+  #  2) consuming it: pivot_wider() below would re-materialize a
+  #     (npopcomb x nblocks) matrix that is exactly t(numer) — the same
+  #     matrix f4blockdat_from_geno already had before it expanded to
+  #     long format. The matrix path avoids both round-trips.
+  f4 = f4blockdat_from_geno(pref, popcomb, allsnps = TRUE, return_matrices = TRUE)
+  numer = f4$numer
+  cnt   = f4$cnt
+  bl    = f4$block_lengths
+  rm(f4)
 
   if(verbose) alert_info(paste0('Constructing matrix...\n'))
   x = construct_fstat_matrix(popcomb)
-  ymat = f4blockdat %>%
-    select(pop1:pop4, block, est) %>%
-    pivot_wider(id_cols=1:4, names_from = block, values_from = est) %>%
-    select(-1:-4) %>% as.matrix
-  y = f4pass1$est
-  #ymat = ymat/f4pass1$se
-  #x = x/f4pass1$se
+  # ymat in the long-format path is built by pivot_wider() into a
+  # (npopcomb x nblocks) matrix; that's exactly t(numer).
+  ymat = t(numer)
+  # y was previously f4pass1$est: the bias-corrected jackknife mean per
+  # popcomb computed by f4blockdat_to_f4out (which iterates the long
+  # format with a dplyr group_by; super-linear in number of groups).
+  # matrix_jackknife_est computes the same value column-by-column over
+  # the matrices.
+  y = matrix_jackknife_est(numer, cnt)
+
   if(verbose) alert_info(paste0('Running regression...\n'))
   lh = solve((t(x) %*% x) + diag(ncol(x))*0.00001) %*% t(x)
   b = lh %*% ymat
   bglob = lh %*% y
 
   nblocks = ncol(b)
-  bl = f4blockdat %>% slice(1:nblocks) %>% pull(length)
   f2blocks = array(0, c(npop, npop, nblocks), list(sp, sp, paste0('l', bl)))
   m = matrix(1:npop^2, npop, npop)
   m2 = matrix(1:npop^2, npop, npop, byrow = T)

--- a/R/resampling.R
+++ b/R/resampling.R
@@ -628,3 +628,148 @@ snpdat_to_jackest = function(dat) {
 }
 
 
+# matrix_jackknife_est_full: matrix-vectorized equivalent of the per-popcomb
+# chain
+#
+#   f4blockdat %>% group_by(pop1, pop2, pop3, pop4) %>%
+#     est_to_loo_dat() %>% jack_dat_stats() %>% pull(est)
+#
+# Inputs:
+#   numer: nblocks x npopcomb matrix of per-block estimates (NA / NaN / Inf
+#          treated as missing)
+#   cnt:   nblocks x npopcomb matrix of per-block valid SNP counts
+# Returns:
+#   numeric vector of length npopcomb with the bias-corrected jackknife mean
+#   per popcomb. NA where the popcomb has no valid blocks.
+#
+# Math equivalence:
+#   est_to_loo_dat assigns
+#     rel_bl = n / sum(n)
+#     tot    = weighted.mean(est, n, na.rm=TRUE)
+#     loo    = (tot - est * rel_bl) / (1 - rel_bl)
+#   jack_dat_stats then computes (over finite-loo rows only)
+#     tot2 = weighted.mean(loo, 1 - n/sum(n), na.rm=TRUE)
+#     est  = mean(tot2 - loo, na.rm=TRUE) * n() + weighted.mean(loo, n, na.rm=TRUE)
+#
+# This function evaluates that across all popcombs simultaneously via column
+# operations on the input matrices. It is intended as a fast replacement for
+# the dplyr group_by chain when many popcombs are processed at once
+# (npopcomb in the millions on dense f4 runs); the dplyr path scales
+# super-linearly in the number of groups and dominates qpfstats wall time
+# at large pop sets.
+#
+# Used internally by matrix_jackknife_est (which adds chunking to bound
+# peak memory).
+matrix_jackknife_est_full = function(numer, cnt) {
+
+  # Step 1: est_to_loo_dat (vectorized across all popcombs)
+  valid = is.finite(numer)
+
+  # rel_bl = n / sum(n) over the FULL group (all blocks regardless of
+  # est validity). Matches dplyr's mutate(rel_bl = n/sum(n)) before
+  # the later filter(is.finite(loo)).
+  sum_n_all = colSums(cnt)
+  sum_n_all[sum_n_all == 0] = NA_real_
+  rel_bl = sweep(cnt, 2, sum_n_all, '/')
+
+  # tot = weighted.mean(est, n, na.rm=TRUE). Per base R weighted.mean,
+  # na.rm=TRUE drops weights corresponding to NA x; sum(w) is then over
+  # the post-filter weights, not over all w. So both numerator and
+  # denominator here sum over `valid` (= is.finite(numer)) rows only.
+  numer_safe  = numer; numer_safe[!valid]  = 0
+  cnt_for_tot = cnt;   cnt_for_tot[!valid] = 0
+  sum_w_for_tot = colSums(cnt_for_tot)
+  sum_w_for_tot[sum_w_for_tot == 0] = NA_real_
+  tot = colSums(numer_safe * cnt_for_tot) / sum_w_for_tot
+
+  # loo[i, j] = (tot[j] - est[i, j] * rel_bl[i, j]) / (1 - rel_bl[i, j])
+  # `numer_safe = 0` at !valid would let loo = tot/(1-rel_bl), a finite
+  # value; dplyr's `NA * rel_bl = NA` propagates instead. Mask afterwards.
+  loo = sweep(-numer_safe * rel_bl, 2, tot, '+') / (1 - rel_bl)
+  loo[!valid] = NA
+  loo[!is.finite(loo)] = NA  # 0/0 from rel_bl = 1 (single-block popcomb)
+
+  # Step 2: jack_dat_stats (est field; var/se/z/p not needed by qpfstats)
+  #
+  #   tot2 = weighted.mean(loo, 1-n/sum(n), na.rm=TRUE)
+  #
+  # Same weighted.mean na.rm semantic as above: filter rows where loo is
+  # NA, then sum both numerator and denominator over the remaining
+  # (finite-loo) rows.
+  #
+  #   filter(is.finite(loo)) %>%
+  #   mutate(est = mean(tot - loo, na.rm=TRUE) * n() +
+  #                weighted.mean(loo, n, na.rm=TRUE))
+  finite_loo = is.finite(loo)
+  loo_safe = loo; loo_safe[!finite_loo] = 0
+
+  omrb = 1 - rel_bl
+  omrb_for_w = omrb; omrb_for_w[!finite_loo] = 0
+  sum_omrb_w = colSums(omrb_for_w)
+  sum_omrb_w[sum_omrb_w == 0] = NA_real_
+  tot2 = colSums(loo_safe * omrb_for_w) / sum_omrb_w
+
+  n_finite = colSums(finite_loo + 0)
+  sum_loo  = colSums(loo_safe)
+  cnt_for_loo = cnt; cnt_for_loo[!finite_loo] = 0
+  sum_n_finite = colSums(cnt_for_loo)
+  sum_n_finite[sum_n_finite == 0] = NA_real_
+  weighted_loo_mean = colSums(loo_safe * cnt_for_loo) / sum_n_finite
+
+  # est = mean(tot2 - loo, na.rm=TRUE) * n_finite + weighted.mean(loo, n, na.rm=TRUE)
+  #     = (n_finite * tot2 - sum_loo)/n_finite * n_finite + weighted_loo_mean
+  #     = n_finite * tot2 - sum_loo + weighted_loo_mean
+  n_finite * tot2 - sum_loo + weighted_loo_mean
+}
+
+
+# .matrix_jackknife_chunk_size: pick a default popcomb-chunk size that keeps
+# transient intermediate matrices below `target_bytes_per_intermediate`.
+# matrix_jackknife_est_full holds ~10 such matrices simultaneously, so a
+# 5e8-byte target gives ~5 GB peak per chunk regardless of total npopcomb.
+.matrix_jackknife_chunk_size = function(nblocks, target_bytes_per_intermediate = 5e8) {
+  cs = as.integer(floor(target_bytes_per_intermediate / (nblocks * 8)))
+  max(1L, cs)
+}
+
+
+# matrix_jackknife_est: chunked wrapper over matrix_jackknife_est_full.
+#
+# At very large npopcomb (e.g. 1.5M+ on a dense 60-pop f4 set), the
+# intermediates inside matrix_jackknife_est_full (10x nblocks x npopcomb
+# doubles) can peak above 100 GB. Processing popcombs in chunks keeps the
+# peak bounded while remaining math-identical, since every column operation
+# in matrix_jackknife_est_full is column-independent.
+#
+# chunk_size:
+#   NULL (default) — auto-sized via .matrix_jackknife_chunk_size to ~5 GB
+#                    peak per chunk
+#   integer        — explicit chunk size; values >= ncol(numer) skip chunking
+#                    and call matrix_jackknife_est_full directly
+matrix_jackknife_est = function(numer, cnt, chunk_size = NULL) {
+  np = ncol(numer)
+  if (np == 0L) return(numeric(0))
+  nb = nrow(numer)
+  if (is.null(chunk_size)) chunk_size = .matrix_jackknife_chunk_size(nb)
+  chunk_size = min(as.integer(chunk_size), np)
+
+  # If everything fits in one chunk, skip the chunking machinery entirely.
+  if (chunk_size >= np) return(matrix_jackknife_est_full(numer, cnt))
+
+  out = numeric(np)
+  starts = seq.int(1L, np, by = chunk_size)
+  for (s in starts) {
+    e = min(s + chunk_size - 1L, np)
+    cols = s:e
+    out[cols] = matrix_jackknife_est_full(
+      numer[, cols, drop = FALSE],
+      cnt[,   cols, drop = FALSE]
+    )
+    # Free this chunk's intermediates before the next chunk allocates;
+    # without this hint, R's mark-sweep GC can defer collection past the
+    # next allocation peak.
+    if (length(starts) > 1L) gc(verbose = FALSE)
+  }
+  out
+}
+

--- a/tests/testthat/test-matrix-jackknife-est.R
+++ b/tests/testthat/test-matrix-jackknife-est.R
@@ -1,0 +1,159 @@
+# Tests for matrix_jackknife_est_full / matrix_jackknife_est (PR #108).
+#
+# Headline contract: the matrix-vectorized helpers produce per-popcomb
+# bias-corrected jackknife estimates that are mathematically equivalent
+# to the long-format dplyr chain in f4blockdat_to_f4out:
+#
+#   f4blockdat %>% group_by(pop1, pop2, pop3, pop4) %>%
+#     est_to_loo_dat() %>% jack_dat_stats() %>% pull(est)
+#
+# The matrix helpers replace this chain in qpfstats to (a) avoid the
+# super-linear dplyr group_by overhead at large npopcomb and (b) avoid
+# the (npopcomb * nblocks)-row long-format build entirely. Tests
+# verify the math equivalence on synthetic input.
+
+# Build a synthetic (numer, cnt) pair plus the matching long-format
+# tibble that the dplyr chain expects. Seeded so the test is
+# deterministic across runs.
+.build_synth_inputs = function(nblocks = 50L, npopcomb = 30L, na_frac = 0.05,
+                               seed = 20260520L) {
+  withr::with_seed(seed, {
+    numer = matrix(rnorm(nblocks * npopcomb, sd = 0.01),
+                   nrow = nblocks, ncol = npopcomb)
+    cnt   = matrix(sample(50:200, nblocks * npopcomb, replace = TRUE),
+                   nrow = nblocks, ncol = npopcomb)
+    # Sprinkle NAs in numer to exercise the !is.finite(est) path in
+    # est_to_loo_dat and jack_dat_stats.
+    numer[sample.int(length(numer),
+                     size = round(na_frac * length(numer)))] = NA_real_
+
+    # Long-format tibble matching the shape f4blockdat_from_geno would
+    # emit. Pop labels are synthesized to be unique per popcomb so the
+    # dplyr group_by partitions exactly the columns of numer/cnt.
+    popcomb = tibble::tibble(
+      pop1 = sprintf("P%dA", seq_len(npopcomb)),
+      pop2 = sprintf("P%dB", seq_len(npopcomb)),
+      pop3 = sprintf("P%dC", seq_len(npopcomb)),
+      pop4 = sprintf("P%dD", seq_len(npopcomb))
+    )
+    f4bd = popcomb %>%
+      tidyr::expand_grid(block = seq_len(nblocks)) %>%
+      dplyr::mutate(
+        est = c(numer), n = c(cnt),
+        length = sample(1000:5000, dplyr::n(), replace = TRUE),
+        est = dplyr::if_else(is.finite(est) & n > 0, est, NA_real_))
+  })
+  list(numer = numer, cnt = cnt, f4bd = f4bd, popcomb = popcomb,
+       nblocks = nblocks, npopcomb = npopcomb)
+}
+
+test_that("matrix_jackknife_est_full matches dplyr f4blockdat_to_f4out on synthetic input", {
+  fx = .build_synth_inputs()
+
+  ref = admixtools:::f4blockdat_to_f4out(fx$f4bd, FALSE)$est
+  new = admixtools:::matrix_jackknife_est_full(fx$numer, fx$cnt)
+
+  # Values should agree within FP summation-order noise. Observed max
+  # abs diff on this fixture is ~1 ULP (2.2e-16); tolerance 1e-13
+  # catches regressions that would introduce >100 ULPs while still
+  # tolerating natural cross-platform FP variation.
+  expect_equal(unname(ref), unname(new), tolerance = 1e-13)
+})
+
+test_that("matrix_jackknife_est_full handles high-NA-fraction input (30% NA)", {
+  # Production f-stat data on ancient-DNA panels can have 30-60% NA per
+  # popcomb after the per-block usesnps mask. Stress-test the matrix
+  # path's NA propagation at that scale by inflating na_frac. The
+  # equivalence vs dplyr should hold to the same FP-rounding tolerance
+  # as at low-NA scale -- if the matrix path mishandles NA propagation,
+  # it would show up here as a substantial diff.
+  fx = .build_synth_inputs(nblocks = 100L, npopcomb = 40L, na_frac = 0.30)
+
+  ref = admixtools:::f4blockdat_to_f4out(fx$f4bd, FALSE)$est
+  new = admixtools:::matrix_jackknife_est_full(fx$numer, fx$cnt)
+
+  # Same tolerance as the low-NA test -- high NA fraction shouldn't
+  # amplify rounding beyond 1 ULP at this fixture size.
+  expect_equal(unname(ref), unname(new), tolerance = 1e-13)
+
+  # Sanity: with 30% NA per cell across 100 blocks, some popcombs will
+  # have <2 valid blocks -- those return NA in both paths. NA pattern
+  # must match between matrix and dplyr.
+  expect_identical(is.na(ref), is.na(new))
+})
+
+test_that("matrix_jackknife_est (chunked) matches matrix_jackknife_est_full (unchunked) bitwise", {
+  # Chunking is column-independent: every operation in
+  # matrix_jackknife_est_full is a per-column sweep or colSums.
+  # Chunked output must therefore be byte-identical to unchunked,
+  # not just numerically equivalent.
+  fx = .build_synth_inputs(nblocks = 40L, npopcomb = 25L)
+
+  unchunked = admixtools:::matrix_jackknife_est_full(fx$numer, fx$cnt)
+  chunked   = admixtools:::matrix_jackknife_est(fx$numer, fx$cnt, chunk_size = 7L)
+
+  expect_identical(unchunked, chunked)
+})
+
+test_that("matrix_jackknife_est: NULL chunk_size auto-sizes and matches full path", {
+  # The wrapper with chunk_size = NULL picks a chunk size that keeps
+  # peak memory bounded. For small inputs the auto-sized chunk is
+  # >= npopcomb and the wrapper bypasses the chunking machinery
+  # entirely, returning matrix_jackknife_est_full's output directly.
+  fx = .build_synth_inputs(nblocks = 30L, npopcomb = 20L)
+  auto = admixtools:::matrix_jackknife_est(fx$numer, fx$cnt, chunk_size = NULL)
+  full = admixtools:::matrix_jackknife_est_full(fx$numer, fx$cnt)
+  expect_identical(auto, full)
+})
+
+test_that("all-NA popcomb returns NA in matrix_jackknife_est_full", {
+  # Construct an input where one popcomb has every block's est = NA.
+  # That row's rel_bl denominator is sum(n) > 0 but its tot is NaN
+  # (0/0), and the final est should be NA (not crash, not Inf).
+  fx = .build_synth_inputs(nblocks = 20L, npopcomb = 5L)
+  fx$numer[, 3L] = NA_real_   # popcomb 3 has all-NA blocks
+
+  new = admixtools:::matrix_jackknife_est_full(fx$numer, fx$cnt)
+  expect_true(is.na(new[3]))
+  # Other popcombs still have finite output.
+  expect_true(all(!is.na(new[-3])))
+})
+
+test_that("single-valid-block popcomb matches dplyr (both return the surviving block's est)", {
+  # Popcomb 1 has only block 1 valid (blocks 2-3 are NA in numer). The
+  # math reduces to: tot = weighted.mean(est, n) = est[1]; after the
+  # is.finite(loo) filter only block 1 survives; n_finite = 1; the
+  # final formula yields est[1]. Verified against dplyr in the same
+  # test (NOT a hard-coded NA assumption).
+  numer = matrix(c(1.0, NA_real_, NA_real_,    # popcomb 1: 1 valid block
+                   2.0, 3.0,      4.0),         # popcomb 2: 3 valid blocks
+                 nrow = 3, ncol = 2)
+  cnt   = matrix(rep(100, 6), nrow = 3, ncol = 2)
+
+  new = admixtools:::matrix_jackknife_est_full(numer, cnt)
+
+  # Build the matching long-format tibble for the dplyr reference.
+  popcomb = tibble::tibble(pop1 = c("A1", "A2"), pop2 = c("B1", "B2"),
+                           pop3 = c("C1", "C2"), pop4 = c("D1", "D2"))
+  f4bd = popcomb %>%
+    tidyr::expand_grid(block = 1:3) %>%
+    dplyr::mutate(est = c(numer), n = c(cnt), length = 100L,
+                  est = dplyr::if_else(is.finite(est) & n > 0, est, NA_real_))
+  ref = admixtools:::f4blockdat_to_f4out(f4bd, FALSE)$est
+
+  expect_equal(unname(ref), unname(new), tolerance = 1e-12)
+  # Popcomb 1 should equal the surviving block's est (1.0).
+  expect_equal(new[1], 1.0, tolerance = 1e-12)
+})
+
+test_that(".matrix_jackknife_chunk_size returns a positive integer scaling inversely with nblocks", {
+  # ~5 GB target / 8 bytes per double = 625e6 doubles per intermediate;
+  # divided by nblocks gives chunk size in popcombs.
+  expect_gte(admixtools:::.matrix_jackknife_chunk_size(100L),
+             admixtools:::.matrix_jackknife_chunk_size(1000L))
+  expect_true(is.integer(admixtools:::.matrix_jackknife_chunk_size(100L)))
+  expect_gte(admixtools:::.matrix_jackknife_chunk_size(1000L), 1L)
+  # At pathologically large nblocks the chunk size must still be >= 1
+  # (the helper clamps via max(1L, ...)).
+  expect_gte(admixtools:::.matrix_jackknife_chunk_size(1e9), 1L)
+})


### PR DESCRIPTION
Replaces `qpfstats`'s long-format detour through `f4blockdat` with direct matrix consumption. Two coupled changes that together make `qpfstats` viable on dense f4 sets where the long-format frame would otherwise dominate memory and runtime.

### Why

`qpfstats` currently calls `f4blockdat_from_geno`, expands the result to a long-format tibble of size `npopcomb * nblocks` rows, then runs the per-popcomb jackknife via `f4blockdat_to_f4out` (a `dplyr group_by(pop1..pop4) %>% summarize` chain). Two costs:

1. **Memory in the long-format build.** `f4blockdat_from_geno` does `expand_grid(popcombs, block = 1:numblocks)` which materializes the full `(npopcomb × nblocks)` frame. For dense f4 runs (e.g. 1.5M popcombs × ~1300 blocks ≈ 2 billion rows) this peaks at hundreds of GB and is a hard ceiling on the workload.
2. **Runtime in the per-popcomb jackknife.** `f4blockdat_to_f4out` does `group_by(pop1, pop2, pop3, pop4) %>% est_to_loo_dat() %>% jack_dat_stats()`. dplyr's per-group data-mask evaluation scales super-linearly in the number of groups — on a 60-pop run this single step hung 16+ minutes single-threaded with all BLAS workers parked, in pure `Rf_eval` recursion.

The matrix path skips both: avoids building the long format at all, and processes all popcombs simultaneously via column operations.

### What this PR does

1. **`f4blockdat_from_geno` gains `return_matrices = FALSE`.** When `TRUE`, it returns the underlying `nblocks × npopcomb` matrices (`numer`, `cnt`, `denom`) plus `popcombs` / `block_lengths` / `f4mode` / `hasmodels` metadata, skipping the `expand_grid` long-format build. Default is `FALSE`, so all existing callers see exactly the same return value as before.

2. **New internal helpers in `R/resampling.R`:**
   - `matrix_jackknife_est_full(numer, cnt)` — vectorized equivalent of `f4blockdat %>% group_by(pop1..pop4) %>% est_to_loo_dat() %>% jack_dat_stats() %>% pull(est)`. Computes the bias-corrected jackknife mean per popcomb directly from the matrices via column-wise operations.
   - `matrix_jackknife_est(numer, cnt, chunk_size = NULL)` — chunked wrapper that bounds peak memory at large `npopcomb` (auto-targets ~5 GB per chunk; column operations are independent so the chunked output is identical to the un-chunked).
   - `.matrix_jackknife_chunk_size(nblocks, target_bytes_per_intermediate)` — internal sizing helper.

   All three are non-exported (`@noRd` style — added without `@export` tags, matching the rest of `R/resampling.R`).

3. **`qpfstats` body** now calls `f4blockdat_from_geno(..., return_matrices = TRUE)`, replaces the `pivot_wider` build of `ymat` with `t(numer)` (which is the same matrix, without the round-trip through long format), and replaces the `f4blockdat_to_f4out(FALSE)$est` extraction with `matrix_jackknife_est(numer, cnt)`. Downstream regression and `f2blocks` construction are unchanged.

### Verification

#### Synthetic equivalence (`matrix_jackknife_est` vs `f4blockdat_to_f4out`)

```r
set.seed(42); nb <- 50L; np <- 80L
numer <- matrix(rnorm(nb*np, sd=0.01), nb, np)
cnt   <- matrix(sample(50:200, nb*np, replace=TRUE), nb, np)
numer[sample.int(nb*np, 0.05*nb*np)] <- NA  # 5% NA
popcomb <- tibble::tibble(pop1=sprintf("P%dA", 1:np), pop2=sprintf("P%dB", 1:np),
                          pop3=sprintf("P%dC", 1:np), pop4=sprintf("P%dD", 1:np))
f4bd <- popcomb |> tidyr::expand_grid(block = 1:nb) |>
  dplyr::mutate(est = c(numer), n = c(cnt),
                length = sample(1000:5000, dplyr::n(), replace=TRUE),
                est = dplyr::if_else(is.finite(est) & n > 0, est, NA_real_))
ref <- admixtools:::f4blockdat_to_f4out(f4bd, FALSE)$est
new <- admixtools:::matrix_jackknife_est_full(numer, cnt)
all.equal(unname(ref), unname(new), tolerance = 1e-12)   # TRUE
# max abs diff = 4.5e-17 (FP summation-order noise)
```

Tested all (allsnps × poly_only) combinations plus all-NA edge case plus chunked-vs-unchunked. Bytewise identical in every case (max abs diff = 4.5e-17 across NA-rich synthetic inputs).

#### End-to-end equivalence (`qpfstats` integration)

Ran `qpfstats` on 18 pops × 713 blocks (Patterson 2021–style real ancient-DNA data) against:

- **Long-format path** (current `master` + the readr fix from #101)
- **Matrix path** (this PR + #101–#107 stacked)

Result on the same input:

| metric | value |
|---|---|
| `dim(f2blocks2)` | 18×18×713 (both paths) |
| max abs diff | **2.148e-14** |
| max rel diff (where reference > 1e-6) | 1.281e-11 |
| cells with diff > 1e-10 | **0 / 231,012** |
| 99.9th percentile of diffs | 2.14e-14 |

Output is bytewise-equivalent at full real-data scale on this workload. The remaining nanoscale diff is FP summation-order noise from doing the arithmetic over a different layout.

Runtime on this 18-pop test (n2-standard-16, 14 workers): qpfstats finished in ~1.1 minutes peak ~1.8 GB RSS. The matrix path is also a clear runtime win at scale (eliminates the 16+ minute dplyr group_by hang on bigger pop sets) but that's not the load-bearing claim of this PR — correctness equivalence is.

### Compatibility

- Default `return_matrices = FALSE` preserves existing behavior for any external code that calls `f4blockdat_from_geno` directly.
- `matrix_jackknife_est_*` are not exported, so they don't expand the public API.
- `qpfstats`'s signature, semantics, and return value are unchanged.

### Relationship to the other open PRs

This PR builds on top of the stack but is independent of any of them:

- It does **not** require #106 (parallelization) — the matrix path is just as correct (and beneficial) on the sequential loop. PR #106 makes `f4blockdat_from_geno` faster; this PR makes the post-loop processing within `qpfstats` faster and more memory-efficient.
- It does **not** require #107 (streaming `cpp_aftable_to_dstatnum_rowmeans`) — this PR consumes whatever `numer` matrix `f4blockdat_from_geno` produces.
- It would compose cleanly with whichever of those land in any order.

Verified locally that this PR + #101 (readr) applies cleanly against current `master` and that `f4blockdat_from_geno` callers other than `qpfstats` (e.g. `qpadm`, `qpdstat`) continue to receive their long-format frame unchanged.
