### PR TITLE
emit per-chromosome progress messages from f4blockdat_from_geno (extract_f2/extract_f3)

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -3093,9 +3093,15 @@ f4blockdat_from_geno = function(pref, popcombs = NULL, left = NULL, right = NULL
       chr_block_count   = 0L
       chr_variant_count = 0L
     }
-    current_chr       = this_chr
-    chr_block_count   = chr_block_count + 1L
-    chr_variant_count = chr_variant_count + block_lengths[i]
+    # Skip accumulation for blocks with no kept SNPs (block_chr is NA). Without
+    # this guard, an empty block's variant count would silently roll into the
+    # next valid chromosome's rollup, inflating it. Triggers only if keepsnps
+    # or auto_only removes every variant from a block.
+    if(!is.na(this_chr)) {
+      current_chr       = this_chr
+      chr_block_count   = chr_block_count + 1L
+      chr_variant_count = chr_variant_count + block_lengths[i]
+    }
 
     if(verbose) alert_info(paste0('Computing ', nrow(pc),' f4-statistics for block ',
                                   i, ' out of ', numblocks, '...\r'))

--- a/R/io.R
+++ b/R/io.R
@@ -3059,8 +3059,44 @@ f4blockdat_from_geno = function(pref, popcombs = NULL, left = NULL, right = NULL
     mutate(popind = map(pp, ~match(., pops))) %$% popind
   usesnps = matrix(0)
 
+  # Per-block chromosome assignment for end-of-chrom progress messages.
+  # snpfile$CHR for any kept SNP in block i gives the chromosome — blocks
+  # are partitioned per-chromosome by get_block_lengths(), so all kept SNPs
+  # in a block share a single CHR. The fill() above also propagates `block`
+  # to dropped SNPs, but we filter to keep=TRUE here so CHR comes from a
+  # real (autosomal/keepsnps) variant.
+  block_chr = vapply(seq_len(numblocks), function(i) {
+    snpfile$CHR[snpfile$block == i & snpfile$keep][1]
+  }, character(1))
+
+  # Heartbeat-progress state. Per chromosome, we accumulate variant count
+  # and elapsed time; on the first block of a NEW chromosome (or on the
+  # end of the loop) we emit one summary line to stderr via message().
+  # Orchestrators that monitor extract_f2 for a heartbeat get one line
+  # per chromosome — typically 22-24 lines total over a 10-60 minute run.
+  process_start_time = Sys.time()
+  chr_start_time     = process_start_time
+  current_chr        = NA_character_
+  chr_block_count    = 0L
+  chr_variant_count  = 0L
+
   numer = denom = cnt = matrix(NA, numblocks, nrow(pc))
   for(i in 1:numblocks) {
+    # On transition to a new chromosome, emit the rollup for the chromosome
+    # we just finished.
+    this_chr = block_chr[i]
+    if(verbose && !is.na(current_chr) && !is.na(this_chr) && this_chr != current_chr) {
+      dt_sec = as.numeric(difftime(Sys.time(), chr_start_time, units = 'secs'))
+      message(sprintf('[extract_f2] chr%s: %d variants in %d blocks (%.1fs)',
+                      current_chr, chr_variant_count, chr_block_count, dt_sec))
+      chr_start_time    = Sys.time()
+      chr_block_count   = 0L
+      chr_variant_count = 0L
+    }
+    current_chr       = this_chr
+    chr_block_count   = chr_block_count + 1L
+    chr_variant_count = chr_variant_count + block_lengths[i]
+
     if(verbose) alert_info(paste0('Computing ', nrow(pc),' f4-statistics for block ',
                                   i, ' out of ', numblocks, '...\r'))
     # replace following two lines with cpp_geno_to_afs?
@@ -3084,6 +3120,23 @@ f4blockdat_from_geno = function(pref, popcombs = NULL, left = NULL, right = NULL
       den = cpp_aftable_to_dstatden(at, p1, p2, p3, p4, modelvec, usesnps, allsnps, poly_only)
       denom[i,] = unname(rowMeans(den, na.rm = TRUE))
     }
+  }
+  # Emit the rollup for the final chromosome (the in-loop transition
+  # check fires on chrom CHANGE, so the last chrom needs its own emit).
+  # Then a single "done" line with totals for the orchestrator's
+  # final-state marker.
+  if(verbose && !is.na(current_chr)) {
+    dt_sec = as.numeric(difftime(Sys.time(), chr_start_time, units = 'secs'))
+    message(sprintf('[extract_f2] chr%s: %d variants in %d blocks (%.1fs)',
+                    current_chr, chr_variant_count, chr_block_count, dt_sec))
+  }
+  if(verbose) {
+    total_sec = as.numeric(difftime(Sys.time(), process_start_time, units = 'secs'))
+    n_chr     = length(unique(block_chr[!is.na(block_chr)]))
+    mins      = floor(total_sec / 60)
+    secs      = total_sec - 60 * mins
+    message(sprintf('[extract_f2] done: %d variants across %d block(s) on %d chromosome(s) in %dm%05.2fs',
+                    sum(block_lengths), numblocks, n_chr, mins, secs))
   }
   if(verbose) cat('\n')
 


### PR DESCRIPTION
Adds per-chromosome progress messages to `f4blockdat_from_geno()` (the per-block loop that powers `extract_f2()` / `extract_f3()`). Orchestrators that wrap `extract_f2` and need a "still alive, still making progress" signal currently see only the in-loop `\r`-overwriting `alert_info()` line, which never reaches stderr in non-interactive contexts.

## What it looks like

On a real run (Patterson 2021 brit dataset, 1.15M variants, 83 blocks, 22 chromosomes):

```
[extract_f2] chr1: 93166 variants in 6 blocks (1.7s)
[extract_f2] chr2: 99391 variants in 6 blocks (1.6s)
[extract_f2] chr3: 82776 variants in 5 blocks (1.4s)
...
[extract_f2] chr22: 16996 variants in 1 blocks (0.3s)
[extract_f2] done: 1147953 variants across 83 block(s) on 22 chromosome(s) in 0m16.03s
```

22 chromosome rollup lines + 1 done line, written via `message()` so they go to stderr and can be captured/forwarded by an orchestrator's log pipeline without interleaving with stdout return values.

## Mechanism

- `block_chr` is pre-computed once via `vapply` over `snpfile$CHR[snpfile$block == i & snpfile$keep]`. `get_block_lengths()` already partitions blocks per-chromosome, so every kept SNP in a block shares a single CHR — `[1]` is safe.
- The per-block loop tracks `chr_block_count`, `chr_variant_count`, `chr_start_time` and emits the rollup on chromosome transition (`block_chr[i] != current_chr`).
- After the loop: a final-chrom rollup (the in-loop check fires on transition, so the last chrom would otherwise be silent) plus a totals line.

## Compatibility

- `verbose`-gated. `verbose = FALSE` callers see no new output and no behavior change.
- Bytewise-identical return value: verified `identical()` on the returned tibble between `verbose = TRUE` and `verbose = FALSE` on the Patterson 2021 brit run (max abs diff on est/se = 0).
- No new dependencies. No API changes.
- Diff: +53 / -0 lines in `R/io.R`, scoped to one function.

## Scope

Independent of every other open PR. Applies to upstream `master` directly.
