### PR TITLE
fix qpadm-on-precomp crash: filter back-end-specific args before forwarding to f2_from_precomp

### DIFF
--- a/R/fstats.R
+++ b/R/fstats.R
@@ -455,7 +455,17 @@ get_f2 = function(f2_data, pops = NULL, pops2 = NULL, afprod = FALSE, verbose = 
   if(!is.character(f2_data)) {
     f2_blocks = f2_data
   } else if(dir.exists(f2_data)) {
-    f2_blocks = f2_from_precomp(f2_data, pops = pops, pops2 = pops2, afprod = afprod, verbose = verbose, ...)
+    # `get_f2`'s `argnam` validator unions formals across all three back-ends, so
+    # callers (e.g. qpadm) routinely pass args (auto_only, blgsize, poly_only,
+    # maxmiss, ...) that only `f2_from_geno` understands. Those args have no
+    # effect on a precomputed cache — block partitioning and SNP filtering
+    # already happened at `extract_f2`-time — so we drop them silently here.
+    # Without this, the qpadm-on-precomp path crashes with "unused arguments".
+    extra = list(...)
+    extra = extra[names(extra) %in% names(formals(f2_from_precomp))]
+    f2_blocks = do.call(f2_from_precomp,
+                        c(list(f2_data, pops = pops, pops2 = pops2, afprod = afprod, verbose = verbose),
+                          extra))
   } else {
     f2_blocks = f2_from_geno(f2_data, pops = union(pops, pops2), afprod = afprod, verbose = verbose, ...)
   }


### PR DESCRIPTION
Fixes a crash in the standard `qpadm()`-on-precomputed-f2-directory workflow.

## Repro on `master`

```r
library(admixtools)
extract_f2(prefix, outdir = f2_dir, pops = c(target, sources, right), overwrite = TRUE)
qpadm(f2_dir, target = target, left = sources, right = right)
# Error in f2_from_precomp(f2_data, pops = pops, pops2 = pops2,
#     afprod = afprod, verbose = verbose, ...) :
#   unused arguments (auto_only = TRUE, blgsize = 0.05, poly_only = FALSE)
```

## Root cause

`qpadm()` calls `get_f2()` like this (R/qpadm.R, the `data` is not a geno prefix branch):

```r
f2_blocks = get_f2(data, pops = c(left, right),
                   auto_only = auto_only,
                   blgsize   = blgsize,
                   poly_only = poly_only,
                   afprod    = TRUE,
                   verbose   = verbose)
```

`get_f2()` validates `...` against the union of formals from all three back-ends — `f2_from_geno`, `f2_from_precomp`, `qpfstats` — so the validator at the top of `get_f2()` lets every plausible arg through regardless of which back-end will run:

```r
argnam = c(names(formals(f2_from_geno)),
           names(formals(f2_from_precomp)),
           names(formals(qpfstats)))
if(!all(...names() %in% argnam)) stop(...)
```

But when `data` is a precomp directory, `get_f2()` then forwards the whole `...` to `f2_from_precomp()`:

```r
} else if(dir.exists(f2_data)) {
  f2_blocks = f2_from_precomp(f2_data, pops = pops, pops2 = pops2,
                              afprod = afprod, verbose = verbose, ...)
}
```

`f2_from_precomp()`'s formals are `(dir, inds, pops, pops2, afprod, fst, return_array, apply_corr, remove_na, verbose)`. `auto_only`, `blgsize`, `poly_only` are `f2_from_geno`-only — they're block-partitioning / SNP-filtering decisions that happen at `extract_f2()`-time, not when reading a precomputed cache. Forwarding them to `f2_from_precomp()` blows up at call time.

## Fix

Filter `...` to args `f2_from_precomp` actually accepts before forwarding:

```r
} else if(dir.exists(f2_data)) {
  extra = list(...)
  extra = extra[names(extra) %in% names(formals(f2_from_precomp))]
  f2_blocks = do.call(f2_from_precomp,
                      c(list(f2_data, pops = pops, pops2 = pops2,
                             afprod = afprod, verbose = verbose),
                        extra))
}
```

The validator at the top of `get_f2()` still rejects truly unknown names, so this doesn't widen the public surface — it just stops forwarding back-end-specific args to the wrong back-end. Silently dropping (instead of warning) matches the existing union-of-formals validator's intent: callers shouldn't have to know which back-end will be picked.

## Verification

Bundled `example_f2_blocks` written to a precomp directory via `write_f2()`, then driven through the exact failing call shape:

| | pre-fix | post-fix |
|---|---|---|
| `qpadm(precomp_dir, ...)` succeeds | ❌ unused-args error | ✅ completes |
| `weights` match manual workaround | n/a | ✅ `identical()` |
| `rankdrop$p` match | n/a | ✅ `identical()` |
| `popdrop$p` match | n/a | ✅ `identical()` |
| `get_f2(..., nonsense_arg = 42)` still rejected | ✅ | ✅ |

The "manual workaround" is `f2_from_precomp(out, ..., afprod = TRUE) %>% qpadm(...)` — the in-memory-array path that the bug-report's user pointed to. The post-fix `qpadm(precomp_dir, ...)` produces a bytewise-identical result.

## Compatibility

- Single-file change; ~10 lines in `R/fstats.R::get_f2()`.
- No public API change. Callers that supply args `f2_from_precomp()` does accept (e.g. `apply_corr`, `fst`) continue to see them through.
- No new dependencies.

## Scope

Closes [carstenerickson/admixtools#7](https://github.com/carstenerickson/admixtools/issues/7). Independent of every other open PR.
