### PR TITLE
qpadm: surface rcond + SVD-based collinearity diagnostic for near-singular f4_var

### DIFF
--- a/R/qpadm.R
+++ b/R/qpadm.R
@@ -114,10 +114,22 @@ qpadm_weights = function(xmat, qinv, rnk, fudge = 0.0001, iterations = 20,
 #' @param constrained Constrain admixture weights to be non-negative
 #' @param return_f4 Return f4-statistics
 #' @param cpp Use C++ functions. Setting this to `FALSE` will be slower but can help with debugging.
+#' @param singular_threshold If not `NA` (the default), error out when the
+#'   reciprocal condition number of the (fudged) f4 variance matrix is below
+#'   this threshold. A common choice is `1e-12` — below that the downstream
+#'   `solve()` and the C++ weight optimization fall back to a pseudo-inverse,
+#'   which makes the returned weight standard errors numerically tight in a
+#'   way that doesn't reflect actual sampling uncertainty. The default
+#'   (`NA`) preserves the historical behavior: silently fall through to the
+#'   pseudo-inverse fallback. In either mode, the reciprocal condition
+#'   number is reported as `f4_var_rcond` on the returned list so callers
+#'   can gate downstream interpretations programmatically.
 #' @param verbose Print progress updates
 #' @param ... If `data` is the prefix of genotype files, additional arguments will be passed to \code{\link{f4blockdat_from_geno}}
-#' @return `qpadm` returns a list with up to four data frames describing the model fit:
+#' @return `qpadm` returns a list with up to four data frames describing the model fit, plus a numeric `f4_var_rcond` diagnostic:
 #' \enumerate{
+#' \item `f4_var_rcond`: Reciprocal condition number of the (fudged) f4 variance matrix that was inverted to compute weights and standard errors. Values near machine epsilon (~`1e-15`) indicate that the right populations are linearly dependent (e.g., a right pop is a sister to one of the sources), and the returned weight SEs may be artificially tight as a result of the pseudo-inverse fallback. See `singular_threshold` for opt-in error gating.
+#' \item `f4_var_singular_loadings`: When `f4_var_rcond` is concerningly low (< `1e-8`), a tibble with one row per right population, sorted by L2 loading on the smallest right-singular vector of `f4_var`. Right pops at the top of this list are the most likely offenders — typically a sister-clade pair (two pops with similar high loadings) or a lone right pop too close to a source. `NULL` otherwise.
 #' \item `weights`: A data frame with estimated admixture proportions where each row is a left population.
 #' \item `f4`: A data frame with estimated and fitted f4-statistics
 #' \item `rankdrop`: A data frame describing model fits with different ranks, including *p*-values for the overall fit
@@ -162,7 +174,8 @@ qpadm_weights = function(xmat, qinv, rnk, fudge = 0.0001, iterations = 20,
 qpadm = function(data, left, right, target, f4blocks = NULL,
                  fudge = 0.0001, fudge_twice = FALSE, auto_only = TRUE, blgsize = 0.05,
                  poly_only = FALSE, boot = FALSE, getcov = TRUE,
-                 constrained = FALSE, return_f4 = FALSE, cpp = TRUE, verbose = TRUE, ...) {
+                 constrained = FALSE, return_f4 = FALSE, cpp = TRUE,
+                 singular_threshold = NA_real_, verbose = TRUE, ...) {
 
   #----------------- prepare f4 stats -----------------
   f2_blocks = NULL
@@ -236,8 +249,81 @@ qpadm = function(data, left, right, target, f4blocks = NULL,
   block_lengths = f4stats$block_lengths
   diag(f4_var) = diag(f4_var) + fudge*sum(diag(f4_var))
   if(fudge_twice) diag(f4_var) = diag(f4_var) + fudge*sum(diag(f4_var))
+
+  # Reciprocal condition number of (fudged) f4 variance matrix. Used as a
+  # diagnostic for "are the right pops independent of the sources?".
+  # Very low rcond (~1e-15 / machine epsilon) typically means one or more
+  # right pops are sister to a source, which makes f4_var near-singular and
+  # the downstream pseudo-inverse fallback in cpp_qpadm_weights produce
+  # weight SEs that look tight but reflect numerical noise, not sampling
+  # uncertainty (issue #8).
+  f4_var_rcond = tryCatch(as.numeric(rcond(f4_var)), error = function(e) NA_real_)
+
+  # If rcond is concerningly low, compute the SVD-based attribution: the
+  # smallest right-singular vector tells us which (left, right) f4 directions
+  # are in the degenerate subspace. Reshape to a (R-1, L-1) matrix (f4_var's
+  # vec ordering puts right-pop fast, left-pop slow — see f4blocks_to_f4stats
+  # in this file and arr3d_to_mat in utility.R) and take row norms to get
+  # per-right-pop loadings on the degenerate direction. Two right pops with
+  # large opposing loadings = sister-like pair; one with a dominant loading
+  # alone = the lone offender.
+  rcond_concern = 1e-8     # below ~sqrt(machine eps), the fit is suspect
+  # Trigger SVD attribution whenever either condition holds:
+  #   (a) the auto-concern bar is hit (always-on diagnostic at very low rcond), or
+  #   (b) the caller asked for fail-loud gating and the threshold actually trips
+  #       (so the error message can include the attribution).
+  trigger_loadings = is.finite(f4_var_rcond) &&
+    (f4_var_rcond < rcond_concern ||
+     (!is.na(singular_threshold) && f4_var_rcond < singular_threshold))
+  f4_var_singular_loadings = NULL
+  if(trigger_loadings) {
+    f4_var_singular_loadings = tryCatch({
+      svd_res = svd(f4_var)
+      v_min = svd_res$v[, ncol(svd_res$v)]                # smallest-sigma right singular vector
+      v_mat = matrix(v_min, nrow = length(right) - 1)     # rows = right[-1], cols = left[-1]
+      right_norms = sqrt(rowSums(v_mat^2))
+      tibble::tibble(right = right[-1], loading = right_norms) %>%
+        dplyr::arrange(dplyr::desc(loading))
+    }, error = function(e) NULL)
+  }
+
+  if(!is.na(singular_threshold) && is.finite(f4_var_rcond) && f4_var_rcond < singular_threshold) {
+    diag_msg = ""
+    if(!is.null(f4_var_singular_loadings)) {
+      top = utils::head(f4_var_singular_loadings, 5)
+      diag_msg = paste0(
+        "\n  Right pops loading on the degenerate direction (top 5):\n",
+        paste0(sprintf("    %-40s loading %.3f", top$right, top$loading), collapse = "\n"),
+        "\n  Pops at the top of this list are the likely offenders — typically a\n",
+        "  sister-clade pair (two pops with similar high loadings) or a lone right\n",
+        "  pop too close to a source. Drop one and refit.")
+    }
+    stop(sprintf(
+      paste0("f4 variance matrix is near-singular (rcond = %.3g < threshold %.3g).\n",
+             "  This typically means right populations aren't independent of the\n",
+             "  sources (e.g. sister populations).%s\n",
+             "  (Pass `singular_threshold = NA` to allow the pseudo-inverse fallback\n",
+             "  anyway; weight SEs may be unreliable.)"),
+      f4_var_rcond, singular_threshold, diag_msg))
+  }
+  if(is.finite(f4_var_rcond) && f4_var_rcond < rcond_concern && is.na(singular_threshold) && verbose) {
+    # Concerning rcond, but no threshold gate set. Surface a warning so the
+    # user knows the result of the silent pseudo-inverse fallback might be
+    # numerically tight in a way that doesn't reflect sampling uncertainty.
+    top = if(!is.null(f4_var_singular_loadings)) utils::head(f4_var_singular_loadings, 3) else NULL
+    diag_msg = if(is.null(top)) "" else paste0(
+      " Right pops loading on the degenerate direction: ",
+      paste0(sprintf("%s (%.2f)", top$right, top$loading), collapse = ", "), ".")
+    warning(sprintf(
+      paste0("f4 variance matrix is near-singular (rcond = %.3g).%s ",
+             "Weight SEs may be unreliable; see `?qpadm` (`singular_threshold`) for ",
+             "opt-in fail-loud gating, and `out$f4_var_singular_loadings` for the full table."),
+      f4_var_rcond, diag_msg))
+  }
+
   qinv = solve(f4_var)
-  out = list()
+  out = list(f4_var_rcond = f4_var_rcond,
+             f4_var_singular_loadings = f4_var_singular_loadings)
 
   #----------------- compute admixture weights -----------------
   if(!is.null(target)) {
@@ -301,10 +387,11 @@ qpadm = function(data, left, right, target, f4blocks = NULL,
 #' qpwave(example_f2_blocks, left, right)
 qpwave = function(data, left, right,
                   fudge = 0.0001, auto_only = TRUE, blgsize = 0.05, poly_only = FALSE, boot = FALSE,
-                  constrained = FALSE, cpp = TRUE, verbose = TRUE)
+                  constrained = FALSE, cpp = TRUE, singular_threshold = NA_real_, verbose = TRUE)
   qpadm(data = data, left = left, right = right, target = NULL,
         fudge = fudge, auto_only = auto_only, blgsize = blgsize, poly_only = poly_only,  boot = boot,
-        constrained = constrained, cpp = cpp, verbose = verbose)
+        constrained = constrained, cpp = cpp,
+        singular_threshold = singular_threshold, verbose = verbose)
 
 
 

--- a/R/qpadm.R
+++ b/R/qpadm.R
@@ -257,7 +257,7 @@ qpadm = function(data, left, right, target, f4blocks = NULL,
   # the downstream pseudo-inverse fallback in cpp_qpadm_weights produce
   # weight SEs that look tight but reflect numerical noise, not sampling
   # uncertainty (issue #8).
-  f4_var_rcond = tryCatch(as.numeric(rcond(f4_var)), error = function(e) NA_real_)
+  f4_var_rcond = tryCatch(rcond(f4_var), error = function(e) NA_real_)
 
   # If rcond is concerningly low, compute the SVD-based attribution: the
   # smallest right-singular vector tells us which (left, right) f4 directions
@@ -317,7 +317,8 @@ qpadm = function(data, left, right, target, f4blocks = NULL,
     warning(sprintf(
       paste0("f4 variance matrix is near-singular (rcond = %.3g).%s ",
              "Weight SEs may be unreliable; see `?qpadm` (`singular_threshold`) for ",
-             "opt-in fail-loud gating, and `out$f4_var_singular_loadings` for the full table."),
+             "opt-in fail-loud gating; the returned list includes the full ",
+             "right-pop loading table on the `f4_var_singular_loadings` field."),
       f4_var_rcond, diag_msg))
   }
 

--- a/man/qpadm.Rd
+++ b/man/qpadm.Rd
@@ -20,6 +20,7 @@ qpadm(
   constrained = FALSE,
   return_f4 = FALSE,
   cpp = TRUE,
+  singular_threshold = NA_real_,
   verbose = TRUE,
   ...
 )
@@ -63,13 +64,26 @@ equal to the number of SNP blocks.}
 
 \item{cpp}{Use C++ functions. Setting this to \code{FALSE} will be slower but can help with debugging.}
 
+\item{singular_threshold}{If not \code{NA} (the default), error out when the
+reciprocal condition number of the (fudged) f4 variance matrix is below
+this threshold. A common choice is \code{1e-12} - below that the downstream
+\code{solve()} and the C++ weight optimization fall back to a pseudo-inverse,
+which makes the returned weight standard errors numerically tight in a
+way that doesn't reflect actual sampling uncertainty. The default
+(\code{NA}) preserves the historical behavior: silently fall through to the
+pseudo-inverse fallback. In either mode, the reciprocal condition
+number is reported as \code{f4_var_rcond} on the returned list so callers
+can gate downstream interpretations programmatically.}
+
 \item{verbose}{Print progress updates}
 
 \item{...}{If \code{data} is the prefix of genotype files, additional arguments will be passed to \code{\link{f4blockdat_from_geno}}}
 }
 \value{
-\code{qpadm} returns a list with up to four data frames describing the model fit:
+\code{qpadm} returns a list with up to four data frames describing the model fit, plus a numeric \code{f4_var_rcond} diagnostic:
 \enumerate{
+\item \code{f4_var_rcond}: Reciprocal condition number of the (fudged) f4 variance matrix that was inverted to compute weights and standard errors. Values near machine epsilon (~\code{1e-15}) indicate that the right populations are linearly dependent (e.g., a right pop is a sister to one of the sources), and the returned weight SEs may be artificially tight as a result of the pseudo-inverse fallback. See \code{singular_threshold} for opt-in error gating.
+\item \code{f4_var_singular_loadings}: When \code{f4_var_rcond} is concerningly low (< \code{1e-8}), a tibble with one row per right population, sorted by L2 loading on the smallest right-singular vector of \code{f4_var}. Right pops at the top of this list are the most likely offenders - typically a sister-clade pair (two pops with similar high loadings) or a lone right pop too close to a source. \code{NULL} otherwise.
 \item \code{weights}: A data frame with estimated admixture proportions where each row is a left population.
 \item \code{f4}: A data frame with estimated and fitted f4-statistics
 \item \code{rankdrop}: A data frame describing model fits with different ranks, including \emph{p}-values for the overall fit

--- a/man/qpwave.Rd
+++ b/man/qpwave.Rd
@@ -15,6 +15,7 @@ qpwave(
   boot = FALSE,
   constrained = FALSE,
   cpp = TRUE,
+  singular_threshold = NA_real_,
   verbose = TRUE
 )
 }

--- a/tests/testthat/test-qpadm-singular-threshold.R
+++ b/tests/testthat/test-qpadm-singular-threshold.R
@@ -1,0 +1,162 @@
+# Tests for the rcond + SVD-based collinearity diagnostic on qpadm()
+# (closes pipeline issue #8). The diagnostic surfaces two fields on the
+# qpadm return list:
+#
+#   f4_var_rcond            -- always present; reciprocal condition number
+#                              of the (fudged) f4 variance matrix.
+#   f4_var_singular_loadings -- populated only when f4_var_rcond < 1e-8;
+#                              tibble with one row per right pop ranked by
+#                              L2 loading on the smallest singular vector.
+#
+# Plus a new singular_threshold = NA_real_ argument that, when set,
+# converts the silent pseudo-inverse fallback into a fail-loud error.
+#
+# Singular-case fixture: clone one of example_f2_blocks's populations
+# into a new dimname with bit-identical f2 values. The cloned pair is
+# perfectly collinear with respect to every other population, which
+# makes the unfudged f4_var rank-deficient. qpadm's default `fudge =
+# 1e-4` regularizes that deficiency away (rcond ~ 1e-4), so to exercise
+# the auto-warn-at-1e-8 path we pass `fudge = 1e-12`; for the fail-loud
+# path we keep default fudge and set `singular_threshold` above the
+# fudge-induced rcond.
+
+.clone_pop_in_f2_blocks = function(f2, src = "Mbuti.DG", dst = "Mbuti_clone") {
+  nam = dimnames(f2)[[1]]
+  if(!(src %in% nam)) stop("source pop not in f2_blocks: ", src)
+  if(dst %in% nam)    stop("destination pop already exists: ", dst)
+  n   = length(nam)
+  nb  = dim(f2)[3]
+  new_nam = c(nam, dst)
+  out = array(NA_real_, dim = c(n + 1, n + 1, nb),
+              dimnames = list(new_nam, new_nam, dimnames(f2)[[3]]))
+  out[1:n, 1:n, ] = f2
+  src_idx = match(src, nam)
+  # Make column (n+1) and row (n+1) byte-identical to src's column/row.
+  out[1:n,   n+1, ] = f2[1:n, src_idx, ]
+  out[n+1,   1:n, ] = f2[src_idx, 1:n, ]
+  out[n+1,   n+1, ] = 0
+  out
+}
+
+# Standard 3-source / 4-right qpadm fit on example_f2_blocks.
+.example_setup = function() {
+  data("example_f2_blocks", package = "admixtools", envir = environment())
+  list(
+    f2     = get("example_f2_blocks", envir = environment()),
+    target = "Denisova.DG",
+    left   = c("Altai_Neanderthal.DG", "Vindija.DG"),
+    right  = c("Chimp.REF", "Mbuti.DG", "Russia_Ust_Ishim.DG",
+               "Switzerland_Bichon.SG")
+  )
+}
+
+# ── clean case ──────────────────────────────────────────────────────────────
+
+test_that("clean qpadm fit reports finite f4_var_rcond above the concern bar with no loadings table", {
+  s = .example_setup()
+  res = suppressMessages(suppressWarnings(
+    qpadm(s$f2, left = s$left, right = s$right, target = s$target,
+          verbose = FALSE)
+  ))
+  expect_true("f4_var_rcond" %in% names(res))
+  expect_true(is.finite(res$f4_var_rcond))
+  expect_gt(res$f4_var_rcond, 1e-8)
+  expect_null(res$f4_var_singular_loadings)
+})
+
+# ── singular case, warn-only (auto-1e-8 bar) ───────────────────────────────
+
+test_that("clone-pair with tiny fudge triggers the loadings table and a warning at the auto-1e-8 bar", {
+  # Construct a clone of Mbuti.DG and put both copies in right[-1]. The two
+  # generate identical f4 statistics for every (left, right[1], right[-1][i])
+  # tuple, so f4_var has identical rows -> rank-deficient. With default
+  # fudge = 1e-4 the regularization lifts rcond above the 1e-8 bar; with
+  # fudge = 1e-12 the deficiency survives and the auto-bar trips. The
+  # smallest singular vector is +/- 1/sqrt(2*nl) on the two clones, giving
+  # row norms of sqrt(1/2) ~ 0.707.
+  s = .example_setup()
+  f2_clone = .clone_pop_in_f2_blocks(s$f2, src = "Mbuti.DG", dst = "Mbuti_clone")
+  right = c("Chimp.REF", "Mbuti.DG", "Mbuti_clone", "Russia_Ust_Ishim.DG",
+            "Switzerland_Bichon.SG")
+
+  warn_msg = NULL
+  res = withCallingHandlers(
+    suppressMessages(qpadm(f2_clone, left = s$left, right = right,
+                            target = s$target, fudge = 1e-12,
+                            verbose = TRUE)),
+    warning = function(w) { warn_msg <<- conditionMessage(w); invokeRestart("muffleWarning") })
+
+  # rcond near machine epsilon, loadings populated, warning fired.
+  expect_lt(res$f4_var_rcond, 1e-8)
+  expect_s3_class(res$f4_var_singular_loadings, "tbl_df")
+  expect_match(warn_msg, "near-singular", fixed = TRUE)
+
+  # The loadings tibble has one row per right[-1] pop (length(right) - 1 = 4).
+  # The two clones should both have loading ~ sqrt(1/2); the others ~ 0.
+  expect_equal(nrow(res$f4_var_singular_loadings), length(right) - 1L)
+  expect_true(all(c("Mbuti.DG", "Mbuti_clone") %in% res$f4_var_singular_loadings$right))
+  clone_loadings = res$f4_var_singular_loadings$loading[
+    res$f4_var_singular_loadings$right %in% c("Mbuti.DG", "Mbuti_clone")]
+  expect_equal(clone_loadings, c(sqrt(0.5), sqrt(0.5)), tolerance = 1e-4)
+})
+
+# ── fail-loud case (singular_threshold set above the post-fudge rcond) ─────
+
+test_that("singular_threshold converts the warning into a fail-loud error with the loadings table", {
+  # Same clone-pair fixture, default fudge (rcond ~ 1e-4 after regularization),
+  # but the caller sets singular_threshold = 1e-3, which is above the post-
+  # fudge rcond. The diagnostic must fire at the threshold rather than at
+  # the auto-1e-8 bar.
+  s = .example_setup()
+  f2_clone = .clone_pop_in_f2_blocks(s$f2, src = "Mbuti.DG", dst = "Mbuti_clone")
+  right = c("Chimp.REF", "Mbuti.DG", "Mbuti_clone", "Russia_Ust_Ishim.DG",
+            "Switzerland_Bichon.SG")
+
+  expect_error(
+    suppressMessages(suppressWarnings(
+      qpadm(f2_clone, left = s$left, right = right, target = s$target,
+            singular_threshold = 1e-3, verbose = FALSE)
+    )),
+    "near-singular"
+  )
+
+  # Error message includes the diagnostic loadings table inline.
+  err = tryCatch(
+    suppressMessages(suppressWarnings(
+      qpadm(f2_clone, left = s$left, right = right, target = s$target,
+            singular_threshold = 1e-3, verbose = FALSE)
+    )),
+    error = function(e) conditionMessage(e))
+  expect_match(err, "Mbuti.DG",    fixed = TRUE)
+  expect_match(err, "Mbuti_clone", fixed = TRUE)
+  expect_match(err, "Drop one and refit", fixed = TRUE)
+})
+
+# ── qpwave plumbing ─────────────────────────────────────────────────────────
+
+test_that("qpwave passes singular_threshold through to qpadm and errors the same way", {
+  # qpwave is qpadm(target = NULL), so the singular_threshold gate must
+  # plumb through identically.
+  s = .example_setup()
+  f2_clone = .clone_pop_in_f2_blocks(s$f2, src = "Mbuti.DG", dst = "Mbuti_clone")
+  right = c("Chimp.REF", "Mbuti.DG", "Mbuti_clone", "Russia_Ust_Ishim.DG",
+            "Switzerland_Bichon.SG")
+
+  expect_error(
+    suppressMessages(suppressWarnings(
+      qpwave(f2_clone, left = s$left, right = right,
+             singular_threshold = 1e-3, verbose = FALSE)
+    )),
+    "near-singular"
+  )
+
+  # And without the threshold (and with default fudge): rcond is regularized
+  # above the auto-bar, so loadings is NULL even though the underlying f4_var
+  # is rank-deficient. This is the documented behavior and matches the
+  # design intent (fudge is supposed to swallow mild collinearity silently).
+  res = suppressMessages(suppressWarnings(
+    qpwave(f2_clone, left = s$left, right = right, verbose = FALSE)
+  ))
+  expect_true(is.finite(res$f4_var_rcond))
+  expect_null(res$f4_var_singular_loadings)
+})


### PR DESCRIPTION
Adds two opt-in / non-breaking diagnostics to `qpadm()` (and `qpwave()`, via threading) that surface near-singularity in the f4 variance matrix — the silent failure mode that causes overconfident weight SEs when right populations are linearly dependent on sources (e.g., a sister-clade right pop).

## Why

When `right` includes a pop too close to one of `left` (or two right pops are sister-clade to each other), the f4 variance matrix `f4_var` becomes rank-deficient. The downstream solve falls through to a pseudo-inverse (arma's silent default; AT2's `#define ARMA_DONT_PRINT_ERRORS` suppresses the warning, though newer RcppArmadillo 15+ leaks it through). The returned weights have tight-looking SEs that reflect *numerical regularization*, not sampling uncertainty.

This is a known footgun — see the customer-side issue [carstenerickson/admixtools#8](https://github.com/carstenerickson/admixtools/issues/8) where a pseudohaploid sample fit gave `z ≈ 21` (implausibly tight for a 44%-weight ancient-DNA sample), and the only signal was an `armadillo:` line on stderr that's easy to miss in pipelines.

## How the original ADMIXTOOLS handles this

For reference: the C reference at [DReichLab/AdmixTools](https://github.com/DReichLab/AdmixTools) uses Patterson's hand-rolled Gaussian elimination ([`src/qpAdm.c::calcadm`](https://github.com/DReichLab/AdmixTools/blob/master/src/qpAdm.c) → [`src/nicksrc/linsubs.c::linsolvx`](https://github.com/DReichLab/AdmixTools/blob/master/src/nicksrc/linsubs.c)) with a fixed Tikhonov-style retry on detected singularity:

```c
if (t==0) break;
++baditer;
if (verbose) printf("singular matrix: %3d %12.6f\n", baditer, ytrace);
addco(coeff, ytrace*.001, n);   // diag += 0.001 * trace, retry up to 10x
```

No condition-number reporting anywhere in the C source tree (grep for `rcond|condition number` → zero hits). The "singular matrix" diagnostic is gated on `verbose` (off by default). So the reference is also effectively silent in normal use, just with a 0.1%-of-trace ridge retry instead of arma's pseudo-inverse. After this patch, AT2 is **strictly more diagnostic** than the reference.

## What this PR adds

### Tier 1 — rcond surface + opt-in fail-loud gate

- New `singular_threshold = NA_real_` argument on `qpadm()` and `qpwave()`. Default `NA` = current behavior (silent pseudo-inverse fallback).
- `out$f4_var_rcond` is *always* populated: the reciprocal condition number of the (fudged) f4 variance matrix.
- When `singular_threshold` is set and `rcond < threshold`, errors with an actionable message instead of returning a numerically-rescued garbage fit.

### Tier 2 — SVD-based right-pop attribution

When `rcond` is concerning (below `1e-8`, or any user-supplied `singular_threshold`), compute the SVD of `f4_var`, reshape the smallest right-singular vector to `(R-1, L-1)`, take row L2 norms = per-right-pop loadings on the degenerate direction. The result is surfaced as `out$f4_var_singular_loadings` (tibble) and folded into the threshold-trip error message.

The signature of an exact-clone sister pair is two right pops at loading ≈ `1/√2 ≈ 0.707` with the rest at ~0 (verified below). For real near-sister pairs the loadings degrade smoothly toward that signature.

## Example error message (threshold trips)

```
f4 variance matrix is near-singular (rcond = 0.000266 < threshold 0.001).
  This typically means right populations aren't independent of the
  sources (e.g. sister populations).
  Right pops loading on the degenerate direction (top 5):
    Mbuti_sister                             loading 0.707
    Mbuti.DG                                 loading 0.707
    Russia_Ust_Ishim.DG                      loading 0.000
    Switzerland_Bichon.SG                    loading 0.000
  Pops at the top of this list are the likely offenders — typically a
  sister-clade pair (two pops with similar high loadings) or a lone right
  pop too close to a source. Drop one and refit.
  (Pass `singular_threshold = NA` to allow the pseudo-inverse fallback
  anyway; weight SEs may be unreliable.)
```

## Verification

Tested on the bundled `example_f2_blocks`:

| | rcond | loadings | weights |
|---|---|---|---|
| clean (4 right pops) | `4.03e-3` | NULL | unchanged from current main |
| clean + `singular_threshold = 1e-12` | `4.03e-3` | NULL | identical to default mode (no-op) |
| polluted (`Mbuti_sister = Mbuti.DG` clone) + `singular_threshold = 1e-3` | `2.66e-4` | `Mbuti_sister: 0.707, Mbuti.DG: 0.707, others: ~0` | errors before solve |
| polluted, no threshold | `2.66e-4` | NULL (fudge keeps rcond above 1e-8 auto-bar) | weights returned silently (current behavior) |
| `qpwave(..., singular_threshold = 1e-3)` on polluted | — | included in error message | errors before solve |

## Compatibility

- Pure additive args, both default to `NA_real_` → no behavior change for existing callers.
- New result fields `f4_var_rcond` and `f4_var_singular_loadings` are extras; existing `weights`/`f4`/`rankdrop`/`popdrop` are unchanged.
- No new dependencies. Threads through `qpwave()` automatically.

## Out of scope (deliberately)

**Patterson's Tikhonov retry was considered and rejected.** The C reference silently bumps `diag += 0.001 * trace` and retries — that "rescue mode" silently regularizes unidentifiable models and returns artificially-tight SEs, which is *the failure mode this PR is explicitly trying to expose*. If you want a structured rescue path it should be a separate flag (`rescue_singular = TRUE`) with an effective-DoF correction to the SE estimator. Without that correction, the user gets the same overconfident-SE problem with a different mechanism.

Closes [carstenerickson#8](https://github.com/carstenerickson/admixtools/issues/8).
