### PR TITLE
Fix drop=FALSE regression + doc warnings from recent PRs

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -3125,6 +3125,12 @@ extract_samples = function(inpref, outpref, inds = NULL, pops = NULL, overwrite 
 #' @param cm_file Optional path to a TSV file with per-variant centimorgan positions
 #'   (columns: a SNP-identifier column and `cm`). Overrides cM values in `.pvar` when supplied.
 #' @param verbose Print progress updates
+#' @param return_matrices If `TRUE`, return a list with `numer`, `cnt`,
+#'   `denom`, and `block_lengths` matrices directly (the matrices the per-
+#'   block reducer writes into) instead of the long-format data frame. Used
+#'   by `qpfstats()` to skip the costly long-format expansion and immediate
+#'   collapse back to matrices. Default `FALSE` preserves the historical
+#'   return shape for all other callers.
 #' @return A data frame with per-block f4-statistics for each population quadruple.
 f4blockdat_from_geno = function(pref, popcombs = NULL, left = NULL, right = NULL, auto_only = TRUE,
                                 blgsize = 0.05,
@@ -3277,7 +3283,12 @@ f4blockdat_from_geno = function(pref, popcombs = NULL, left = NULL, right = NULL
   # The default plan is sequential, so this preserves the original
   # behavior for callers who don't set up a parallel plan.
   process_block = function(i) {
-    gmat = block_reader$reader(start[i], end[i])[,snpind[[i]]]
+    # drop = FALSE: when snpind[[i]] selects a single column R would
+    # silently degrade the matrix to a vector, causing gmat_to_aftable
+    # to throw "Not a matrix" downstream. Triggered by sparse-SNP blocks
+    # (common at chromosome tails or with tight blgsize). The original
+    # extract_f2 path at L3516 has the same guard.
+    gmat = block_reader$reader(start[i], end[i])[, snpind[[i]], drop = FALSE]
     at = gmat_to_aftable(gmat, popvec)
     block_usesnps = usesnps
     if(!allsnps) {
@@ -3679,7 +3690,7 @@ construct_fstat_matrix = function(popcomb) {
 #'   `1e-5` matches the original literal `0.00001` constant.
 #' @return List with elements `b` (npairs x nblocks) and `bglob`
 #'   (length npairs).
-#' @keywords internal
+#' @noRd
 qpfstats_regression = function(x, ymat, y, ridge = 0.00001) {
   nblocks  = ncol(ymat)
   npairs   = ncol(x)

--- a/R/qpadm.R
+++ b/R/qpadm.R
@@ -116,7 +116,7 @@ qpadm_weights = function(xmat, qinv, rnk, fudge = 0.0001, iterations = 20,
 #' @param cpp Use C++ functions. Setting this to `FALSE` will be slower but can help with debugging.
 #' @param singular_threshold If not `NA` (the default), error out when the
 #'   reciprocal condition number of the (fudged) f4 variance matrix is below
-#'   this threshold. A common choice is `1e-12` — below that the downstream
+#'   this threshold. A common choice is `1e-12` -- below that the downstream
 #'   `solve()` and the C++ weight optimization fall back to a pseudo-inverse,
 #'   which makes the returned weight standard errors numerically tight in a
 #'   way that doesn't reflect actual sampling uncertainty. The default
@@ -129,7 +129,7 @@ qpadm_weights = function(xmat, qinv, rnk, fudge = 0.0001, iterations = 20,
 #' @return `qpadm` returns a list with up to four data frames describing the model fit, plus a numeric `f4_var_rcond` diagnostic:
 #' \enumerate{
 #' \item `f4_var_rcond`: Reciprocal condition number of the (fudged) f4 variance matrix that was inverted to compute weights and standard errors. Values near machine epsilon (~`1e-15`) indicate that the right populations are linearly dependent (e.g., a right pop is a sister to one of the sources), and the returned weight SEs may be artificially tight as a result of the pseudo-inverse fallback. See `singular_threshold` for opt-in error gating.
-#' \item `f4_var_singular_loadings`: When `f4_var_rcond` is concerningly low (< `1e-8`), a tibble with one row per right population, sorted by L2 loading on the smallest right-singular vector of `f4_var`. Right pops at the top of this list are the most likely offenders — typically a sister-clade pair (two pops with similar high loadings) or a lone right pop too close to a source. `NULL` otherwise.
+#' \item `f4_var_singular_loadings`: When `f4_var_rcond` is concerningly low (< `1e-8`), a tibble with one row per right population, sorted by L2 loading on the smallest right-singular vector of `f4_var`. Right pops at the top of this list are the most likely offenders -- typically a sister-clade pair (two pops with similar high loadings) or a lone right pop too close to a source. `NULL` otherwise.
 #' \item `weights`: A data frame with estimated admixture proportions where each row is a left population.
 #' \item `f4`: A data frame with estimated and fitted f4-statistics
 #' \item `rankdrop`: A data frame describing model fits with different ranks, including *p*-values for the overall fit
@@ -262,7 +262,7 @@ qpadm = function(data, left, right, target, f4blocks = NULL,
   # If rcond is concerningly low, compute the SVD-based attribution: the
   # smallest right-singular vector tells us which (left, right) f4 directions
   # are in the degenerate subspace. Reshape to a (R-1, L-1) matrix (f4_var's
-  # vec ordering puts right-pop fast, left-pop slow — see f4blocks_to_f4stats
+  # vec ordering puts right-pop fast, left-pop slow -- see f4blocks_to_f4stats
   # in this file and arr3d_to_mat in utility.R) and take row norms to get
   # per-right-pop loadings on the degenerate direction. Two right pops with
   # large opposing loadings = sister-like pair; one with a dominant loading
@@ -294,7 +294,7 @@ qpadm = function(data, left, right, target, f4blocks = NULL,
       diag_msg = paste0(
         "\n  Right pops loading on the degenerate direction (top 5):\n",
         paste0(sprintf("    %-40s loading %.3f", top$right, top$loading), collapse = "\n"),
-        "\n  Pops at the top of this list are the likely offenders — typically a\n",
+        "\n  Pops at the top of this list are the likely offenders -- typically a\n",
         "  sister-clade pair (two pops with similar high loadings) or a lone right\n",
         "  pop too close to a source. Drop one and refit.")
     }

--- a/man/f4blockdat_from_geno.Rd
+++ b/man/f4blockdat_from_geno.Rd
@@ -18,7 +18,8 @@ f4blockdat_from_geno(
   snpwt = NULL,
   keepsnps = NULL,
   cm_file = NULL,
-  verbose = TRUE
+  verbose = TRUE,
+  return_matrices = FALSE
 )
 }
 \arguments{
@@ -50,6 +51,13 @@ f4blockdat_from_geno(
 (columns: a SNP-identifier column and \code{cm}). Overrides cM values in \code{.pvar} when supplied.}
 
 \item{verbose}{Print progress updates}
+
+\item{return_matrices}{If \code{TRUE}, return a list with \code{numer}, \code{cnt},
+\code{denom}, and \code{block_lengths} matrices directly (the matrices the per-
+block reducer writes into) instead of the long-format data frame. Used
+by \code{qpfstats()} to skip the costly long-format expansion and immediate
+collapse back to matrices. Default \code{FALSE} preserves the historical
+return shape for all other callers.}
 }
 \value{
 A data frame with per-block f4-statistics for each population quadruple.

--- a/man/qpadm.Rd
+++ b/man/qpadm.Rd
@@ -66,7 +66,7 @@ equal to the number of SNP blocks.}
 
 \item{singular_threshold}{If not \code{NA} (the default), error out when the
 reciprocal condition number of the (fudged) f4 variance matrix is below
-this threshold. A common choice is \code{1e-12} - below that the downstream
+this threshold. A common choice is \code{1e-12} -- below that the downstream
 \code{solve()} and the C++ weight optimization fall back to a pseudo-inverse,
 which makes the returned weight standard errors numerically tight in a
 way that doesn't reflect actual sampling uncertainty. The default
@@ -83,7 +83,7 @@ can gate downstream interpretations programmatically.}
 \code{qpadm} returns a list with up to four data frames describing the model fit, plus a numeric \code{f4_var_rcond} diagnostic:
 \enumerate{
 \item \code{f4_var_rcond}: Reciprocal condition number of the (fudged) f4 variance matrix that was inverted to compute weights and standard errors. Values near machine epsilon (~\code{1e-15}) indicate that the right populations are linearly dependent (e.g., a right pop is a sister to one of the sources), and the returned weight SEs may be artificially tight as a result of the pseudo-inverse fallback. See \code{singular_threshold} for opt-in error gating.
-\item \code{f4_var_singular_loadings}: When \code{f4_var_rcond} is concerningly low (< \code{1e-8}), a tibble with one row per right population, sorted by L2 loading on the smallest right-singular vector of \code{f4_var}. Right pops at the top of this list are the most likely offenders - typically a sister-clade pair (two pops with similar high loadings) or a lone right pop too close to a source. \code{NULL} otherwise.
+\item \code{f4_var_singular_loadings}: When \code{f4_var_rcond} is concerningly low (< \code{1e-8}), a tibble with one row per right population, sorted by L2 loading on the smallest right-singular vector of \code{f4_var}. Right pops at the top of this list are the most likely offenders -- typically a sister-clade pair (two pops with similar high loadings) or a lone right pop too close to a source. \code{NULL} otherwise.
 \item \code{weights}: A data frame with estimated admixture proportions where each row is a left population.
 \item \code{f4}: A data frame with estimated and fitted f4-statistics
 \item \code{rankdrop}: A data frame describing model fits with different ranks, including \emph{p}-values for the overall fit

--- a/man/qpwave.Rd
+++ b/man/qpwave.Rd
@@ -48,6 +48,17 @@ equal to the number of SNP blocks.}
 
 \item{cpp}{Use C++ functions. Setting this to \code{FALSE} will be slower but can help with debugging.}
 
+\item{singular_threshold}{If not \code{NA} (the default), error out when the
+reciprocal condition number of the (fudged) f4 variance matrix is below
+this threshold. A common choice is \code{1e-12} -- below that the downstream
+\code{solve()} and the C++ weight optimization fall back to a pseudo-inverse,
+which makes the returned weight standard errors numerically tight in a
+way that doesn't reflect actual sampling uncertainty. The default
+(\code{NA}) preserves the historical behavior: silently fall through to the
+pseudo-inverse fallback. In either mode, the reciprocal condition
+number is reported as \code{f4_var_rcond} on the returned list so callers
+can gate downstream interpretations programmatically.}
+
 \item{verbose}{Print progress updates}
 }
 \value{

--- a/man/write_dot.Rd
+++ b/man/write_dot.Rd
@@ -25,17 +25,19 @@ write_dot(
 
 \item{outfile}{Output file name}
 
-\item{fontsize}{Font size of edge and node labels}
-
-\item{color}{A boolean specifying if the plot will be in color or grey scale.}
-
-\item{hide_weights}{A boolean value specifying if the drift values on the edges will be hidden. The default is \code{FALSE}.}
-
 \item{size1}{Maximum width of the rendered graph in inches (the first value of Graphviz's \code{size} attribute). The default is \code{7.5}.}
 
 \item{size2}{Maximum height of the rendered graph in inches (the second value of Graphviz's \code{size} attribute). The default is \code{10}.}
 
 \item{title}{Title displayed above the graph. Defaults to the empty string.}
+
+\item{dot2pdf}{If \code{FALSE}, the function will terminate after writing the dot file. If \code{TRUE}, it will try to execute the \code{dot -Tpdf} comment to create pdf file.}
+
+\item{fontsize}{Font size of edge and node labels}
+
+\item{color}{A boolean specifying if the plot will be in color or grey scale.}
+
+\item{hide_weights}{A boolean value specifying if the drift values on the edges will be hidden. The default is \code{FALSE}.}
 
 \item{highlight_unidentifiable}{Highlight unidentifiable edges in red. Can be slow for large graphs.}
 
@@ -44,8 +46,6 @@ write_dot(
 \item{ranksep}{Sets the rank separation, in inches. This is the minimum vertical distance between the bottom of the nodes in one rank and the tops of nodes in the next. The default is \code{0.5}.}
 
 \item{fix_names}{If \code{TRUE}, replaces the dots (.) and dashes (-) in population names with underscores. The default is \code{FALSE}.}
-
-\item{dot2pdf}{If \code{FALSE}, the function will terminate after writing the dot file. If \code{TRUE}, it will try to execute the \code{dot -Tpdf} comment to create pdf file.}
 }
 \description{
 Convert graph to dot format


### PR DESCRIPTION
## Summary

Two-part cleanup PR on the heels of the recent merge batch (#106-#126):

1. **Real bug fix**: `process_block` in `f4blockdat_from_geno` lost a `drop = FALSE` guard during PR #111's PFILE-backend abstraction. Single-SNP blocks now degrade silently to vectors and throw `Rcpp::not_a_matrix` from inside `future_map`. Surfaced by R CMD check via 8 testthat failures (`test-f4blockdat-pfile.R` x3, `test-qpadm-target-null.R` x5).

2. **Doc warnings introduced by recent PRs**:
   - `f4blockdat_from_geno` missing `@param return_matrices` (PR #108)
   - `qpwave.Rd` missing `singular_threshold` (PR #121; Rd never regenerated post-merge)
   - `qpfstats_regression` (PR #112) `@keywords internal` was generating an unwanted man page; switched to `@noRd`
   - `R/qpadm.R` non-ASCII em-dashes (PR #121 diagnostic text) -- one was in a `warning()` message that hit the WARNING; rest in roxygen/comments fixed defensively

## R CMD check --as-cran before / after

| | before | after |
|---|---|---|
| ERRORs | 1 (testthat) | 0 |
| WARNINGs | 5 | 2 (both vignette-build, out of scope) |
| NOTEs | 4 | 4 (all pre-existing) |

The two remaining WARNINGs are about vignettes in `vignettes/` not being built into `inst/doc/`, which is a multi-day vignette-build effort and deserves a separate PR. The four NOTEs (CRAN incoming, missing pandoc, partial arg matches in legacy code, Rd xrefs to non-installed Suggests) are all pre-existing and not from our PRs.

## Tests

After fix: `335 PASS / 0 FAIL` across 109 `test_that` blocks (was `8 FAIL` before the `drop = FALSE` patch).

## Files changed

- `R/io.R`: drop=FALSE on `process_block`; @param return_matrices; @noRd on qpfstats_regression
- `R/qpadm.R`: 4 em-dashes (U+2014) -> `--`
- `man/f4blockdat_from_geno.Rd`, `man/qpadm.Rd`, `man/qpwave.Rd`, `man/write_dot.Rd`: regenerated via `roxygen2::roxygenize`
- `man/qpfstats_regression.Rd`: deleted (was unwanted output from `@keywords internal`)