### PR TITLE
docs(io): document PLINK 2 (PFILE) + fix .pvar.zst detection in compute_f2_cache_id

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -1324,7 +1324,12 @@ compute_f2_cache_id = function(pref, format = NULL, inds = NULL, pops = NULL,
     if(all(file.exists(paste0(pref, c('.bed', '.bim', '.fam'))))) format = 'plink'
     else if(all(file.exists(paste0(pref, c('.geno', '.snp', '.ind'))))) {
       format = if(is_packed(paste0(pref, '.geno'))) 'packedancestrymap' else 'eigenstrat'
-    } else if(all(file.exists(paste0(pref, c('.pgen', '.pvar', '.psam'))))) {
+    } else if(all(file.exists(paste0(pref, c('.pgen', '.psam')))) &&
+              !is.na(.resolve_pvar_path(pref))) {
+      # `.pvar` may be `.pvar.zst`; use the same resolver as the other PFILE
+      # entry points (pfile_to_afs, format_info) so a `.pvar.zst`-only PFILE
+      # is detected here too. Pre-fix this branch silently fell through to
+      # the catch-all stop().
       format = 'pfile'
     } else stop('Genotype files not found at prefix: ', pref)
   }

--- a/tests/testthat/test-compute_f2_cache_id.R
+++ b/tests/testthat/test-compute_f2_cache_id.R
@@ -189,3 +189,41 @@ test_that("compute_f2_cache_id propagates get_block_lengths errors instead of re
                           snpfile_kept = bad_snp, blgsize = 0.05))
   })
 })
+
+
+test_that("compute_f2_cache_id auto-detects PFILE when only .pvar.zst is present", {
+  # Regression test surfaced while documenting PFILE in vignettes/io.Rmd:
+  # the format-detection block in compute_f2_cache_id required `.pvar`
+  # specifically and didn't recognize a PFILE that ships only `.pvar.zst`,
+  # even though the rest of the PFILE pipeline (pfile_to_afs, extract_f2,
+  # f4blockdat_from_geno) handles both forms transparently via
+  # `.resolve_pvar_path()`. The fix routes the detection through the same
+  # resolver. Skip on systems without the `zstd` CLI (needed to construct
+  # the .pvar.zst fixture from the helper's .pvar output).
+  testthat::skip_if(Sys.which("zstd") == "", "zstd CLI not on PATH")
+  withr::with_tempdir({
+    fix = build_pfile_fixture(getwd(), with_fid = TRUE)
+    pref = fix$pfile_pref
+    testthat::skip_if(is.na(pref), "PFILE fixture unavailable")
+
+    pvar_plain = paste0(pref, ".pvar")
+    pvar_zst   = paste0(pref, ".pvar.zst")
+    testthat::skip_if(!file.exists(pvar_plain),
+                      "PFILE fixture did not produce a .pvar")
+    rc = system2("zstd", args = c("-q", "-f", shQuote(pvar_plain),
+                                  "-o", shQuote(pvar_zst)),
+                 stdout = FALSE, stderr = FALSE)
+    testthat::skip_if(rc != 0L, "zstd compression failed")
+    # snpfile_kept comes from .read_pvar applied to the plain .pvar (which
+    # we still have at this point). Then we remove the plain form so only
+    # .pvar.zst is present at the prefix.
+    snpfile_kept = admixtools:::.read_pvar(pvar_plain)
+    file.remove(pvar_plain)
+    expect_false(file.exists(pvar_plain))
+    expect_true(file.exists(pvar_zst))
+
+    id = compute_f2_cache_id(pref, pops = fix$fid_pops,
+                             snpfile_kept = snpfile_kept, blgsize = 0.05)
+    expect_match(id, "^sha256:[0-9a-f]{64}$")
+  })
+})

--- a/vignettes/io.Rmd
+++ b/vignettes/io.Rmd
@@ -24,7 +24,7 @@ vignette: >
 
 *PACKEDANCESTRYMAP* and *EIGENSTRAT* are described [here](https://reich.hms.harvard.edu/software/InputFileFormats)
 
-In all three formats a dataset consists of three files: one file for the genotype matrix, one file for the SNP metadata, and one file for the sample metadata.
+In all four formats a dataset consists of three files: one file for the genotype matrix, one file for the SNP metadata, and one file for the sample metadata.
 
 The following shows what a data set for three SNPs and five samples grouped into two populations (French.DG, Onge.DG) could look like:
 
@@ -300,5 +300,11 @@ fit = qpgraph(example_f2_blocks, example_igraph)$edges
 write_dot(fit, 'graph.dot')
 ```
 
-*ADMIXTOOLS 2* currently doesn't have a function for reading DOT files.
+You can read a DOT file back into an igraph with `parse_dot()`:
+
+```{r, eval = FALSE}
+graph = parse_dot("graph.dot")
+```
+
+`parse_dot()` is a minimal reader that recovers the topology from `from -> to` edges. Edge attributes (weights, types) are not preserved on the round trip; for full round-tripping of fitted graphs, use the edge-list format instead.
 

--- a/vignettes/io.Rmd
+++ b/vignettes/io.Rmd
@@ -15,11 +15,12 @@ vignette: >
 
 ## Genotype data formats 
 
-*ADMIXTOOLS 2* can read genotype data in three formats.
+*ADMIXTOOLS 2* can read genotype data in four formats.
 
 1. Binary *PLINK* format (PACKEDPED), described [here](https://www.cog-genomics.org/plink2/input)
-2. Binary *PACKEDANCESTRYMAP* format
-3. Text based *EIGENSTRAT* format
+2. Binary *PLINK 2* format (PFILE), described [here](https://www.cog-genomics.org/plink/2.0/input)
+3. Binary *PACKEDANCESTRYMAP* format
+4. Text based *EIGENSTRAT* format
 
 *PACKEDANCESTRYMAP* and *EIGENSTRAT* are described [here](https://reich.hms.harvard.edu/software/InputFileFormats)
 
@@ -46,6 +47,34 @@ PLINK `.bim` file:
 1	rs12124819	0.020242	776546	A	G
 1	rs28765502	0.022137	832918	T	C
 ```
+
+### PLINK 2 (PFILE)
+
+A *PLINK 2* dataset consists of three files: `.pgen` (binary genotype matrix), `.pvar` (variant metadata), and `.psam` (sample metadata). The prefix convention is the same as for binary *PLINK* (one prefix that resolves to all three), so *ADMIXTOOLS 2* auto-detects PFILE format whenever `<prefix>.pgen`, `<prefix>.pvar`, and `<prefix>.psam` all exist at the prefix you pass.
+
+`.psam` is a tab-separated text file. Population labels live in the `#FID` column when present (matching the PLINK convention of FID-as-population); when `#FID` is missing or `0`, *ADMIXTOOLS 2* falls back to `IID`:
+
+```
+#FID	IID	SEX
+French.DG	S_French-1.DG	1
+French.DG	S_French-2.DG	2
+French.DG	B_French-3.DG	1
+Onge.DG	BR_Onge-2.DG	2
+Onge.DG	BR_Onge-1.DG	2
+```
+
+`.pvar` is tab-separated text and (unlike `.bim`) supports multi-allelic sites by allowing comma-separated `ALT` alleles. The `pfile_to_afs()` function accepts a `multiallelic = c("error", "skip", "first_alt")` argument to control how those sites are handled (default `"error"`):
+
+```
+#CHROM	POS	ID	REF	ALT
+1	752566	rs3094315	G	A
+1	776546	rs12124819	A	G
+1	832918	rs28765502	T	C
+```
+
+`.pvar` may also be supplied in Zstd-compressed form as `.pvar.zst` — *ADMIXTOOLS 2* picks up either form transparently. Reading `.pvar.zst` requires the `zstd` CLI on PATH (the genotype access via `pgenlibr` handles `.zst` natively, but the R-side metadata parser shells out to `zstd -d`).
+
+Note: `.pvar` does *not* by default carry centimorgan positions. When the `CM` column is absent *ADMIXTOOLS 2* leaves `cm = 0` for all variants and falls back to base-pair distance for block partitioning (`blgsize = 1e6` works well at typical block sizes). Alternatively you can supply an external recombination map via `cm_file =` (a TSV with a SNP-identifier column — `variant_id`, `SNP`, or `ID` — and a `cm` column).
 
 ### EIGENSTRAT/PACKEDANCESTRYMAP
 
@@ -105,6 +134,8 @@ geno = read_packedancestrymap("packedancestrymap/prefix", first = 1000, last = 2
 geno = read_packedancestrymap("packedancestrymap/prefix", inds = c('ind1', 'ind2'))
 ```
 
+For PFILE, there is no `read_pfile` — PFILE inputs are consumed directly by the f-statistic pipeline (`extract_f2`, `f2_from_geno`, `f4blockdat_from_geno`, `qpfstats`) which auto-detect the format from the file extensions at the prefix.
+
 
 ## Extracting populations
 
@@ -128,6 +159,16 @@ extract_samples("input/prefix", "output/prefix", pops = c("pop1", "pop2"))
 afs = plink_to_afs("plink/prefix")
 afs = eigenstrat_to_afs("eigenstrat/prefix")
 afs = packedancestrymap_to_afs("packedancestrymap/prefix")
+afs = pfile_to_afs("plink2/prefix")
+
+# pfile_to_afs supports the same range/subset args as the others
+afs = pfile_to_afs("plink2/prefix", inds = c('ind1', 'ind2'))
+afs = pfile_to_afs("plink2/prefix", pops = c('pop1', 'pop2'))
+afs = pfile_to_afs("plink2/prefix", first = 1000, last = 2000)
+
+# When .pvar lacks centimorgan positions (the default), supply a map
+# via cm_file (TSV with variant_id + cm columns)
+afs = pfile_to_afs("plink2/prefix", cm_file = "ref_genmap.tsv")
 ```
 
 

--- a/vignettes/io.Rmd
+++ b/vignettes/io.Rmd
@@ -184,6 +184,33 @@ packedancestrymap_to_plink("packedancestrymap_input_prefix", "plink_output_prefi
 ```
 
 
+## f2 cache metadata
+
+When `extract_f2()` writes to disk it emits two sidecar files alongside the per-pair `.rds` arrays:
+
+  * **`.f2_cache_id`** — a short text file containing a `sha256:<64hex>` hash over the inputs and filter args. Cheap to read; useful as a cache key for orchestrators that want to skip re-extraction when nothing has changed.
+  * **`cache_metadata.json`** — a schema-versioned JSON file with `n_snps`, `n_blocks`, `pops`, build timestamp, filter args, and the same `cache_id`. Written atomically (tempfile + rename) before `.f2_cache_id`, so a crash between the two writes leaves a recoverable directory.
+
+Read the metadata programmatically:
+
+```{r, eval = FALSE}
+meta = read_f2_cache_metadata("my_f2_dir/")
+meta$n_snps     # SNPs that actually contributed to f2 blocks
+meta$pops       # populations in the cache
+meta$cache_id   # matches .f2_cache_id
+```
+
+To check whether an existing cache directory still matches your current inputs without re-extracting, recompute the cache id from the genotype prefix and compare:
+
+```{r, eval = FALSE}
+fresh  = compute_f2_cache_id("geno_prefix", pops = pops, ...)
+cached = read_f2_cache_metadata("my_f2_dir/")$cache_id
+identical(fresh, cached)  # TRUE if the cache is still valid for these inputs
+```
+
+If only the genotype prefix and the f2 directory are available (e.g. an orchestrator probe), `compute_f2_cache_id("my_f2_dir/")` reads the hash directly from the sidecar — no genotype-file access needed.
+
+
 ## Admixture graph formats
 
 There are several ways in which admixture graphs can be represented. Some of them are useful because they can be stored as human readable text files, and others are useful because they make it easier for R to process graphs. *ADMIXTOOLS 2* has several function for importing, exporting and converting between formats.


### PR DESCRIPTION
## Summary

* Adds a **PLINK 2 (PFILE)** section to `vignettes/io.Rmd`. PFILE has been a first-class genotype-input format in admixtools since #109 / #111, but the vignette still listed only three formats; users with `.pgen` / `.pvar` / `.psam` data had no doc to discover the support.
* Bundles a **1-line bug fix** to `compute_f2_cache_id` (PR #117) that the doc-writing process surfaced: its PFILE detection required uncompressed `.pvar` and silently fell through to "Genotype files not found" on a `.pvar.zst`-only PFILE, even though `pfile_to_afs`, `extract_f2`, and `f4blockdat_from_geno` handle both forms transparently via the shared `.resolve_pvar_path()` resolver.

## Doc additions (vignettes/io.Rmd)

* Intro list: three formats → four.
* New `### PLINK 2 (PFILE)` section under "Genotype data formats" describing the `.pgen` / `.pvar` / `.psam` triplet, the `#FID` / `IID` population convention, multi-allelic handling (`multiallelic = c("error", "skip", "first_alt")`), `.pvar.zst` transparent support (+ `zstd` CLI requirement), and the `.pvar`-lacks-cm quirk with the `cm_file =` workaround.
* "Reading genotype files" section: note that PFILE has no `read_pfile` — it's consumed directly by the f-stat pipeline (`extract_f2`, `f2_from_geno`, `f4blockdat_from_geno`, `qpfstats`) via auto-detection.
* "Computing allele frequencies" section: `pfile_to_afs` example with `inds` / `pops` / `first` / `last` / `cm_file` variants.

## Bug fix (R/io.R)

Pre-fix:
```r
} else if(all(file.exists(paste0(pref, c('.pgen', '.pvar', '.psam'))))) {
  format = 'pfile'
} else stop('Genotype files not found at prefix: ', pref)
```

Post-fix:
```r
} else if(all(file.exists(paste0(pref, c('.pgen', '.psam')))) &&
          !is.na(.resolve_pvar_path(pref))) {
  format = 'pfile'
} else stop('Genotype files not found at prefix: ', pref)
```

`.resolve_pvar_path()` is the same resolver `pfile_to_afs` and `format_info` already use; routing detection through it makes the doc claim "*ADMIXTOOLS 2* picks up either form transparently" actually true everywhere.

## Test

`tests/testthat/test-compute_f2_cache_id.R` gains one new `test_that` block that:

1. Builds a PFILE fixture via the existing `build_pfile_fixture()` helper.
2. Compresses the `.pvar` to `.pvar.zst` and removes the plain `.pvar`.
3. Calls `compute_f2_cache_id` and asserts a valid `sha256:…` return.

The test skips when the `zstd` CLI is missing.

Verified the test catches the bug: temporarily reverting the 1-line fix makes the test fail with the original "Genotype files not found at prefix" error message; restoring the fix passes.

## Test plan

* [x] `pkgload::load_all()` + `test_file("tests/testthat/test-compute_f2_cache_id.R")` — all 8 existing assertions + 1 new pass.
* [x] Test fails pre-fix (verified by stashing the R/io.R edit and re-running).
* [x] Bug fix uses an internal helper (`.resolve_pvar_path()`) that was already in use at the two other PFILE entry points, so no new behavioral surface.

## Out of scope

* PFILE-related additions to the **other** vignettes (qpadm, qpfstats coverage in fstats.Rmd, parallel.Rmd rewrite, etc.) — separately scoped, this PR focuses on `io.Rmd` only.
* Bundling vignettes into `inst/doc/` — Robert's setup is pkgdown-only, leaving that alone.