### PR TITLE
fix: route \r progress lines through cli::cli_inform() for stderr tail-ability

### DIFF
--- a/R/fstats.R
+++ b/R/fstats.R
@@ -112,7 +112,7 @@ afs_to_f2_blocks = function(afdat, maxmem = 8000, blgsize = 0.05,
   }
   #for(i in 1:length(popvecs1)) {
   foreach::foreach(i=1:length(popvecs1)) %do% {
-    if(length(popvecs1) > 1 & verbose) cli::cli_inform(c(i = "pop pair block {i} of {length(popvecs1)}"))
+    if(length(popvecs1) > 1 & verbose) .heartbeat("pop pair block {i} of {length(popvecs1)}")
     s1 = popvecs1[[i]]
     s2 = popvecs2[[i]]
     am1 = afmat[, s1]
@@ -171,7 +171,7 @@ afs_to_f2_blocks = function(afdat, maxmem = 8000, blgsize = 0.05,
     }
     rm(counts, f2); gc()
   }
-  if(length(popvecs1) > 1 & verbose) cat('\n')
+  if(length(popvecs1) > 1 & verbose) .heartbeat(done = TRUE)
   # `block_lengths_f2` is always returned so callers (extract_f2's metadata
   # writer) can size `n_blocks` / `n_snps` without re-reading
   # block_lengths_f2.rds from disk. When outdir is NULL the rest of the in-

--- a/R/fstats.R
+++ b/R/fstats.R
@@ -112,7 +112,7 @@ afs_to_f2_blocks = function(afdat, maxmem = 8000, blgsize = 0.05,
   }
   #for(i in 1:length(popvecs1)) {
   foreach::foreach(i=1:length(popvecs1)) %do% {
-    if(length(popvecs1) > 1 & verbose) cat(paste0('\rpop pair block ', i, ' out of ', length(popvecs1)))
+    if(length(popvecs1) > 1 & verbose) cli::cli_inform(c(i = "pop pair block {i} of {length(popvecs1)}"))
     s1 = popvecs1[[i]]
     s2 = popvecs2[[i]]
     am1 = afmat[, s1]

--- a/R/io.R
+++ b/R/io.R
@@ -163,7 +163,7 @@ eigenstrat_to_afs = function(pref, inds = NULL, pops = NULL, numparts = 100,
 
   for(i in 1:numparts) {
 
-    if(verbose && numparts > 1) alert_info(paste0('Reading part ', i,' of ', numparts,'...\r'))
+    if(verbose && numparts > 1) cli::cli_inform(c(i = "Reading part {i} of {numparts}..."))
     geno = cpp_read_eigenstrat(fl, nsnp, nindall, (indvec != 0)+0, start[i]-1, end[i], FALSE, verbose && numparts == 1)
     colnames(geno) = inds
     counts[start[i]:end[i],] = t(rowsum((!is.na(t(geno)))*ploidy, pops))[,upops]
@@ -1121,7 +1121,7 @@ plink_to_afs = function(pref, inds = NULL, pops = NULL, adjust_pseudohaploid = T
   else ploidy = rep(2, nindall)
 
   for(i in seq_len(numblocks)) {
-    if(numblocks > 1) alert_info(paste0('Reading block ', i,' of ', numblocks,'...\r'))
+    if(numblocks > 1) cli::cli_inform(c(i = "Reading block {i} of {numblocks}..."))
     dat = cpp_plink_to_afs(normalizePath(bedfile), nsnpall, nindall, indvec-1,
                            first = firsts[i]-1, last = lasts[i], ploidy, FALSE, verbose && numblocks == 1)
     if(poly_only) {
@@ -1527,7 +1527,7 @@ read_f2 = function(f2_dir, pops = NULL, pops2 = NULL, type = 'f2',
   # outputs are small (one column of per-block doubles), so the overhead
   # of socket serialization is well below the I/O latency savings on
   # network or cold-cache filesystems.
-  if(verbose) alert_info(paste0('Reading ', type, ' data for ', nrow(popcomb), ' pairs...\r'))
+  if(verbose) cli::cli_inform(c(i = "Reading {type} data for {nrow(popcomb)} pairs..."))
   # seed = NULL asserts that readRDS doesn't use RNG -- suppresses furrr's
   # defensive "UNRELIABLE VALUE" warning under plan(multisession), which it
   # emits whenever the mapped function isn't statically proven RNG-free.
@@ -1549,7 +1549,6 @@ read_f2 = function(f2_dir, pops = NULL, pops2 = NULL, type = 'f2',
     #if(any(is.na(dat))) warning(paste0('missing values in ', pop1, ' - ', pop2, '!'))
   }
   rm(dat_list)
-  if(verbose) alert_info(paste0('\n'))
   if(remove_na || verbose) {
     keep = apply(f2_blocks, 3, function(x) sum(!is.finite(x)) == 0)
     if(!all(keep)) {
@@ -1632,12 +1631,11 @@ split_mat = function(mat, cols_per_chunk, prefix, overwrite = TRUE, verbose = TR
   numparts = length(starts)
   ends = c(lead(starts)[-numparts]-1, npops)
   for(i in seq_len(numparts)) {
-    if(verbose) cat(paste0('\rpart ', i, ' of ', numparts))
+    if(verbose) cli::cli_inform(c(i = "part {i} of {numparts}"))
     spl = mat[, starts[i]:ends[i],drop=F]
     fl = paste0(prefix, i, '.rds')
     if(overwrite || !file.exists(fl)) saveRDS(spl, file = fl)
   }
-  if(verbose) cat('\n')
 }
 
 
@@ -1747,12 +1745,11 @@ write_split_inddat = function(genodir, outdir, overwrite = FALSE, maxmem = 8000,
 
   if(verbose) alert_info(paste0('Writing individual data from ', length(files), ' chunks\n'))
   for(i in seq_len(nfiles)) {
-    if(verbose) alert_info(paste0('Chunk ', i, ' out of ', nfiles, '\r'))
+    if(verbose) cli::cli_inform(c(i = "Chunk {i} of {nfiles}"))
     xmat = 2*readRDS(files[i])
     xmat_to_inddat(xmat, block_lengths, outdir = outdir, overwrite = overwrite,
                    maxmem = maxmem, verbose = FALSE)
   }
-  if(verbose) alert_info(paste0('\n'))
 }
 
 #' Compute count blocks and write them to disk
@@ -2141,7 +2138,7 @@ extract_f2_large = function(pref, outdir, inds = NULL, pops = NULL, blgsize = 0.
   consider running "extract_afs" and then paralellizing over "afs_to_f2".\n'))
   for(i in 1:numchunks) {
     for(j in i:numchunks) {
-      if(verbose) alert_info(paste0('Writing pair ', i, ' - ', j, '...\r'))
+      if(verbose) cli::cli_inform(c(i = "Writing pair {i}-{j}..."))
       afs_to_f2(outdir, outdir, chunk1 = i, chunk2 = j, blgsize = blgsize, snpdat = snpdat,
                 snpwt = snpwt, overwrite = overwrite, type = 'f2', poly_only = 'f2' %in% poly_only,
                 apply_corr = apply_corr)
@@ -2151,7 +2148,6 @@ extract_f2_large = function(pref, outdir, inds = NULL, pops = NULL, blgsize = 0.
                         snpwt = snpwt, overwrite = overwrite, type = 'fst', poly_only = 'fst' %in% poly_only)
     }
   }
-  if(verbose) alert_info('\n')
   if(verbose) alert_info(paste0('Deleting allele frequency files...\n'))
   unlink(paste0(outdir, c('/afs*.rds', '/counts*.rds')))
 }
@@ -2293,11 +2289,10 @@ extract_counts_large = function(pref, outdir, inds = NULL, blgsize = 0.05, cols_
   consider running "extract_afs" (with each individual its own population) and then paralellizing over "afs_to_counts".\n'))
   for(i in 1:numchunks) {
     for(j in i:numchunks) {
-      if(verbose) alert_info(paste0('Writing pair ', i, ' - ', j, '...\r'))
+      if(verbose) cli::cli_inform(c(i = "Writing pair {i}-{j}..."))
       afs_to_counts(outdir, outdir, chunk1 = i, chunk2 = j, overwrite = overwrite)
     }
   }
-  if(verbose) alert_info('\n')
   if(verbose) alert_info(paste0('Deleting allele frequency files...\n'))
   unlink(paste0(outdir, c('/afs*.rds', '/counts*.rds')))
 }
@@ -2430,7 +2425,7 @@ extract_afs = function(pref, outdir, inds = NULL, pops = NULL, cols_per_chunk = 
   else ploidy = rep(2, nindall)
 
   for(i in 1:numparts) {
-    if(verbose) alert_info(paste0('Reading part ', i, ' out of ', numparts, '...\r'))
+    if(verbose) cli::cli_inform(c(i = "Reading part {i} of {numparts}..."))
     # read data and compute allele frequencies
     afdat = l$cpp_geno_to_afs(paste0(pref, l$genoend), nsnpall, nindall, indvec, first = starts[i],
                                 last = ends[i], ploidy = ploidy, transpose = FALSE, verbose = FALSE)
@@ -2453,14 +2448,13 @@ extract_afs = function(pref, outdir, inds = NULL, pops = NULL, cols_per_chunk = 
     split_mat(afdat$afs, cols_per_chunk = cols_per_chunk, prefix = paste0(partdir,'/afs'), verbose = FALSE)
     split_mat(afdat$counts, cols_per_chunk = cols_per_chunk, prefix = paste0(partdir, '/counts'), verbose = FALSE)
   }
-  if(verbose) alert_info('\n')
   snpparts %<>% bind_rows %>% mutate(CHR = as.character(CHR))
   if(verbose) alert_warning(paste0(nrow(snpparts), ' SNPs remain after filtering. ',
                                    sum(snpparts$poly),' are polymorphic.\n'))
 
   numchunks = length(list.files(partdir, 'afs.+rds'))
   for(j in seq_len(numchunks)) {
-    if(verbose) alert_info(paste0('Merging chunk ', j, ' out of ', numchunks, '...\r'))
+    if(verbose) cli::cli_inform(c(i = "Merging chunk {j} of {numchunks}..."))
     am = cm = list()
     for(i in seq_len(numparts)) {
       partdir = paste0(outdir, '/part', i, '/')
@@ -2471,7 +2465,6 @@ extract_afs = function(pref, outdir, inds = NULL, pops = NULL, cols_per_chunk = 
     saveRDS(do.call(rbind, cm), file = paste0(outdir,'/counts', j, '.rds'))
   }
   unlink(paste0(outdir, '/part', seq_len(numparts), '/'), recursive = TRUE)
-  if(verbose) alert_info('\n')
 
   write_tsv(snpparts, paste0(outdir, '/snpdat.tsv.gz'))
   invisible(snpparts)
@@ -2913,7 +2906,7 @@ xmat_to_pairdat = function(xmat, block_lengths, maxmem = 8000,
   aa_list = nn_list = replicate(numsplits2, list())
 
   for(i in 1:ncol(cmb)) {
-    if(numsplits2 > 1 & verbose) alert_info(paste0('sample pair block ', i, ' out of ', ncol(cmb), '\r'))
+    if(numsplits2 > 1 & verbose) cli::cli_inform(c(i = "sample pair block {i} of {ncol(cmb)}"))
     c1 = cmb[1,i]
     c2 = cmb[2,i]
     s1 = starts[c1]:ends[c1]
@@ -2940,7 +2933,6 @@ xmat_to_pairdat = function(xmat, block_lengths, maxmem = 8000,
       nn_list[[c2]][[c1]] = aperm(nn_list[[c1]][[c2]], c(2,1,3))
     }
   }
-  if(numsplits2 > 1 & verbose) alert_info('\n')
 
   if(is.null(outdir)) {
     assemble_arrays = function(l)
@@ -3608,8 +3600,7 @@ f3blockdat_from_geno = function(pref, popcombs, auto_only = TRUE,
 
   numer = denom = cnt = matrix(NA, numblocks, nrow(pc))
   for(i in 1:numblocks) {
-    if(verbose) alert_info(paste0('Computing ', nrow(pc),' f3-statistics for block ',
-                                  i, ' out of ', numblocks, '...\r'))
+    if(verbose) cli::cli_inform(c(i = "Computing {nrow(pc)} f3-statistics for block {i} of {numblocks}..."))
     # replace following two lines with cpp_geno_to_afs?
     gmat = cpp_read_geno(fl, nsnpall, nindall, indvec, start[i], end[i], T, F)[,snpind[[i]],drop=F]
     ref = rowsum(gmat, popvec, na.rm = TRUE)

--- a/R/io.R
+++ b/R/io.R
@@ -163,12 +163,13 @@ eigenstrat_to_afs = function(pref, inds = NULL, pops = NULL, numparts = 100,
 
   for(i in 1:numparts) {
 
-    if(verbose && numparts > 1) cli::cli_inform(c(i = "Reading part {i} of {numparts}..."))
+    if(verbose && numparts > 1) .heartbeat("Reading part {i} of {numparts}...")
     geno = cpp_read_eigenstrat(fl, nsnp, nindall, (indvec != 0)+0, start[i]-1, end[i], FALSE, verbose && numparts == 1)
     colnames(geno) = inds
     counts[start[i]:end[i],] = t(rowsum((!is.na(t(geno)))*ploidy, pops))[,upops]
     afs[start[i]:end[i],] = t(rowsum(t(geno)/(3-ploidy), pops, na.rm=T))[,upops]/counts[start[i]:end[i],]
   }
+  if(verbose && numparts > 1) .heartbeat(done = TRUE)
   afs[!is.finite(afs)] = NA
   rownames(afs) = rownames(counts) = snpfile$SNP
   colnames(afs) = colnames(counts) = upops
@@ -1121,7 +1122,7 @@ plink_to_afs = function(pref, inds = NULL, pops = NULL, adjust_pseudohaploid = T
   else ploidy = rep(2, nindall)
 
   for(i in seq_len(numblocks)) {
-    if(numblocks > 1) cli::cli_inform(c(i = "Reading block {i} of {numblocks}..."))
+    if(numblocks > 1) .heartbeat("Reading block {i} of {numblocks}...")
     dat = cpp_plink_to_afs(normalizePath(bedfile), nsnpall, nindall, indvec-1,
                            first = firsts[i]-1, last = lasts[i], ploidy, FALSE, verbose && numblocks == 1)
     if(poly_only) {
@@ -1135,6 +1136,7 @@ plink_to_afs = function(pref, inds = NULL, pops = NULL, adjust_pseudohaploid = T
     aflist[[i]] = dat$afs
     countlist[[i]] = dat$counts
   }
+  if(numblocks > 1) .heartbeat(done = TRUE)
   bim %<>% slice(snp_indices)
 
   afmatrix = do.call(rbind, aflist)
@@ -1527,7 +1529,7 @@ read_f2 = function(f2_dir, pops = NULL, pops2 = NULL, type = 'f2',
   # outputs are small (one column of per-block doubles), so the overhead
   # of socket serialization is well below the I/O latency savings on
   # network or cold-cache filesystems.
-  if(verbose) cli::cli_inform(c(i = "Reading {type} data for {nrow(popcomb)} pairs..."))
+  if(verbose) .heartbeat("Reading {type} data for {nrow(popcomb)} pairs...")
   # seed = NULL asserts that readRDS doesn't use RNG -- suppresses furrr's
   # defensive "UNRELIABLE VALUE" warning under plan(multisession), which it
   # emits whenever the mapped function isn't statically proven RNG-free.
@@ -1549,6 +1551,7 @@ read_f2 = function(f2_dir, pops = NULL, pops2 = NULL, type = 'f2',
     #if(any(is.na(dat))) warning(paste0('missing values in ', pop1, ' - ', pop2, '!'))
   }
   rm(dat_list)
+  if(verbose) .heartbeat(done = TRUE)
   if(remove_na || verbose) {
     keep = apply(f2_blocks, 3, function(x) sum(!is.finite(x)) == 0)
     if(!all(keep)) {
@@ -1631,11 +1634,12 @@ split_mat = function(mat, cols_per_chunk, prefix, overwrite = TRUE, verbose = TR
   numparts = length(starts)
   ends = c(lead(starts)[-numparts]-1, npops)
   for(i in seq_len(numparts)) {
-    if(verbose) cli::cli_inform(c(i = "part {i} of {numparts}"))
+    if(verbose) .heartbeat("part {i} of {numparts}")
     spl = mat[, starts[i]:ends[i],drop=F]
     fl = paste0(prefix, i, '.rds')
     if(overwrite || !file.exists(fl)) saveRDS(spl, file = fl)
   }
+  if(verbose) .heartbeat(done = TRUE)
 }
 
 
@@ -1745,11 +1749,12 @@ write_split_inddat = function(genodir, outdir, overwrite = FALSE, maxmem = 8000,
 
   if(verbose) alert_info(paste0('Writing individual data from ', length(files), ' chunks\n'))
   for(i in seq_len(nfiles)) {
-    if(verbose) cli::cli_inform(c(i = "Chunk {i} of {nfiles}"))
+    if(verbose) .heartbeat("Chunk {i} of {nfiles}")
     xmat = 2*readRDS(files[i])
     xmat_to_inddat(xmat, block_lengths, outdir = outdir, overwrite = overwrite,
                    maxmem = maxmem, verbose = FALSE)
   }
+  if(verbose) .heartbeat(done = TRUE)
 }
 
 #' Compute count blocks and write them to disk
@@ -2138,7 +2143,7 @@ extract_f2_large = function(pref, outdir, inds = NULL, pops = NULL, blgsize = 0.
   consider running "extract_afs" and then paralellizing over "afs_to_f2".\n'))
   for(i in 1:numchunks) {
     for(j in i:numchunks) {
-      if(verbose) cli::cli_inform(c(i = "Writing pair {i}-{j}..."))
+      if(verbose) .heartbeat("Writing pair {i}-{j}...")
       afs_to_f2(outdir, outdir, chunk1 = i, chunk2 = j, blgsize = blgsize, snpdat = snpdat,
                 snpwt = snpwt, overwrite = overwrite, type = 'f2', poly_only = 'f2' %in% poly_only,
                 apply_corr = apply_corr)
@@ -2148,6 +2153,7 @@ extract_f2_large = function(pref, outdir, inds = NULL, pops = NULL, blgsize = 0.
                         snpwt = snpwt, overwrite = overwrite, type = 'fst', poly_only = 'fst' %in% poly_only)
     }
   }
+  if(verbose) .heartbeat(done = TRUE)
   if(verbose) alert_info(paste0('Deleting allele frequency files...\n'))
   unlink(paste0(outdir, c('/afs*.rds', '/counts*.rds')))
 }
@@ -2289,10 +2295,11 @@ extract_counts_large = function(pref, outdir, inds = NULL, blgsize = 0.05, cols_
   consider running "extract_afs" (with each individual its own population) and then paralellizing over "afs_to_counts".\n'))
   for(i in 1:numchunks) {
     for(j in i:numchunks) {
-      if(verbose) cli::cli_inform(c(i = "Writing pair {i}-{j}..."))
+      if(verbose) .heartbeat("Writing pair {i}-{j}...")
       afs_to_counts(outdir, outdir, chunk1 = i, chunk2 = j, overwrite = overwrite)
     }
   }
+  if(verbose) .heartbeat(done = TRUE)
   if(verbose) alert_info(paste0('Deleting allele frequency files...\n'))
   unlink(paste0(outdir, c('/afs*.rds', '/counts*.rds')))
 }
@@ -2425,7 +2432,7 @@ extract_afs = function(pref, outdir, inds = NULL, pops = NULL, cols_per_chunk = 
   else ploidy = rep(2, nindall)
 
   for(i in 1:numparts) {
-    if(verbose) cli::cli_inform(c(i = "Reading part {i} of {numparts}..."))
+    if(verbose) .heartbeat("Reading part {i} of {numparts}...")
     # read data and compute allele frequencies
     afdat = l$cpp_geno_to_afs(paste0(pref, l$genoend), nsnpall, nindall, indvec, first = starts[i],
                                 last = ends[i], ploidy = ploidy, transpose = FALSE, verbose = FALSE)
@@ -2448,13 +2455,14 @@ extract_afs = function(pref, outdir, inds = NULL, pops = NULL, cols_per_chunk = 
     split_mat(afdat$afs, cols_per_chunk = cols_per_chunk, prefix = paste0(partdir,'/afs'), verbose = FALSE)
     split_mat(afdat$counts, cols_per_chunk = cols_per_chunk, prefix = paste0(partdir, '/counts'), verbose = FALSE)
   }
+  if(verbose) .heartbeat(done = TRUE)
   snpparts %<>% bind_rows %>% mutate(CHR = as.character(CHR))
   if(verbose) alert_warning(paste0(nrow(snpparts), ' SNPs remain after filtering. ',
                                    sum(snpparts$poly),' are polymorphic.\n'))
 
   numchunks = length(list.files(partdir, 'afs.+rds'))
   for(j in seq_len(numchunks)) {
-    if(verbose) cli::cli_inform(c(i = "Merging chunk {j} of {numchunks}..."))
+    if(verbose) .heartbeat("Merging chunk {j} of {numchunks}...")
     am = cm = list()
     for(i in seq_len(numparts)) {
       partdir = paste0(outdir, '/part', i, '/')
@@ -2464,6 +2472,7 @@ extract_afs = function(pref, outdir, inds = NULL, pops = NULL, cols_per_chunk = 
     saveRDS(do.call(rbind, am), file = paste0(outdir,'/afs', j, '.rds'))
     saveRDS(do.call(rbind, cm), file = paste0(outdir,'/counts', j, '.rds'))
   }
+  if(verbose) .heartbeat(done = TRUE)
   unlink(paste0(outdir, '/part', seq_len(numparts), '/'), recursive = TRUE)
 
   write_tsv(snpparts, paste0(outdir, '/snpdat.tsv.gz'))
@@ -2906,7 +2915,7 @@ xmat_to_pairdat = function(xmat, block_lengths, maxmem = 8000,
   aa_list = nn_list = replicate(numsplits2, list())
 
   for(i in 1:ncol(cmb)) {
-    if(numsplits2 > 1 & verbose) cli::cli_inform(c(i = "sample pair block {i} of {ncol(cmb)}"))
+    if(numsplits2 > 1 & verbose) .heartbeat("sample pair block {i} of {ncol(cmb)}")
     c1 = cmb[1,i]
     c2 = cmb[2,i]
     s1 = starts[c1]:ends[c1]
@@ -2933,6 +2942,7 @@ xmat_to_pairdat = function(xmat, block_lengths, maxmem = 8000,
       nn_list[[c2]][[c1]] = aperm(nn_list[[c1]][[c2]], c(2,1,3))
     }
   }
+  if(numsplits2 > 1 & verbose) .heartbeat(done = TRUE)
 
   if(is.null(outdir)) {
     assemble_arrays = function(l)
@@ -3600,7 +3610,7 @@ f3blockdat_from_geno = function(pref, popcombs, auto_only = TRUE,
 
   numer = denom = cnt = matrix(NA, numblocks, nrow(pc))
   for(i in 1:numblocks) {
-    if(verbose) cli::cli_inform(c(i = "Computing {nrow(pc)} f3-statistics for block {i} of {numblocks}..."))
+    if(verbose) .heartbeat("Computing {nrow(pc)} f3-statistics for block {i} of {numblocks}...")
     # replace following two lines with cpp_geno_to_afs?
     gmat = cpp_read_geno(fl, nsnpall, nindall, indvec, start[i], end[i], T, F)[,snpind[[i]],drop=F]
     ref = rowsum(gmat, popvec, na.rm = TRUE)
@@ -3652,7 +3662,7 @@ f3blockdat_from_geno = function(pref, popcombs, auto_only = TRUE,
     numer[i,] = unname(rowSums(num$num, na.rm = TRUE))
     cnt[i,] = c(num$cnt)
   }
-  if(verbose) cat('\n')
+  if(verbose) .heartbeat(done = TRUE)
   out = pc %>%
     expand_grid(block = 1:numblocks) %>%
     mutate(numer = c(numer/cnt), denom = c(denom/cnt), est = numer/denom, n = c(cnt))

--- a/R/toposearch.R
+++ b/R/toposearch.R
@@ -1011,7 +1011,7 @@ get_mutfuns = function(mutfuns, probs, fix_outgroup = TRUE) {
 
 add_generation = function(models, numgraphs, numsel, qpgfun, mutfuns, opt_worst_residual = FALSE, parallel = TRUE, verbose = TRUE) {
 
-  if(verbose) cli::cli_inform(c(i = 'Selecting winners...'))
+  if(verbose) .heartbeat('Selecting winners...')
   lastgen = max(models$generation)
   oldmodels = models %>% filter(generation == lastgen, !is.na(score))
   numsel = min(nrow(oldmodels), numsel)
@@ -1029,15 +1029,17 @@ add_generation = function(models, numgraphs, numsel, qpgfun, mutfuns, opt_worst_
     map = function(...) furrr::future_map(..., .options = furrr::furrr_options(seed = TRUE))
     imap = function(...) furrr::future_imap(..., .options = furrr::furrr_options(seed = TRUE))
   }
-  if(verbose) cli::cli_inform(c(i = 'Generating new graphs...'))
+  if(verbose) .heartbeat('Generating new graphs...')
   newmodels %<>% mutate(mutation = names(mutations),
                         igraph = imap(igraph, ~tryCatch(exec(mutations[[.y]], .x), error = function(e) .x)))
-  if(verbose) cli::cli_inform(c(i = 'Evaluating graphs...'))
+  if(verbose) .heartbeat('Evaluating graphs...')
   newmodels %<>% mutate(out = map(igraph, qpgfun))
-  if(verbose) cli::cli_inform(c(i = 'Attaching to previous generations...'))
-  winners %>%
+  if(verbose) .heartbeat('Attaching to previous generations...')
+  out = winners %>%
     mutate(generation = lastgen+1, index = 1:n()) %>%
     bind_rows(newmodels %>% unnest_wider(out))
+  if(verbose) .heartbeat(done = TRUE)
+  out
 }
 
 
@@ -1101,15 +1103,16 @@ optimize_admixturegraph_single = function(pops, precomp, mutlist, repnum, numgra
   }
 
   # qpgfun = possibly(qpgfun, otherwise = NULL)
-  if(verbose) cli::cli_inform(c(i = 'Generate new graphs...'))
+  if(verbose) .heartbeat('Generate new graphs...')
   if(is.null(initgraphs)) initgraphs = replicate(numgraphs, random_admixturegraph(pops, numadmix, outpop = outpop),
                                                 simplify = FALSE)
   else initgraphs = initgraphs[round(seq(1, length(initgraphs), numgraphs))]
-  if(verbose) cli::cli_inform(c(i = 'Evaluate graphs...'))
+  if(verbose) .heartbeat('Evaluate graphs...')
   if(parallel) map = function(...) furrr::future_map(..., .options = furrr::furrr_options(seed = TRUE))
   init = tibble(generation=0, index = seq_len(numgraphs),
                 igraph = initgraphs, mutation = 'random_admixturegraph') %>%
     mutate(out = map(igraph, qpgfun), isn = map_lgl(out, is.null))
+  if(verbose) .heartbeat(done = TRUE)
   if(all(init$isn)) stop('All NULL!')
 
   init %<>% select(-isn) %>% unnest_wider(out) %>% mutate(oldscore = score, oldindex = index)
@@ -3557,10 +3560,11 @@ identifiable_comb = function(graph, edge, jac = NULL, verbose = TRUE) {
   edges = colnames(jac)
 
   for(i in seq_len(length(E(graph)))) {
-    if(verbose) cli::cli_inform(c(i = "{i}..."))
+    if(verbose) .heartbeat("{i}...")
     us = identifiable_sets(graph, jac, edge = which(edges == edge), n = i)
     if(edge %in% unlist(us)) break
   }
+  if(verbose) .heartbeat(done = TRUE)
   us[map_lgl(seq_len(nrow(us)), ~edge %in% us[.,]),,drop=FALSE]
 }
 

--- a/R/toposearch.R
+++ b/R/toposearch.R
@@ -1011,8 +1011,7 @@ get_mutfuns = function(mutfuns, probs, fix_outgroup = TRUE) {
 
 add_generation = function(models, numgraphs, numsel, qpgfun, mutfuns, opt_worst_residual = FALSE, parallel = TRUE, verbose = TRUE) {
 
-  space = paste0(paste(rep(' ', 50), collapse=''), '\r')
-  if(verbose) alert_info(paste0('Selecting winners...', space))
+  if(verbose) cli::cli_inform(c(i = 'Selecting winners...'))
   lastgen = max(models$generation)
   oldmodels = models %>% filter(generation == lastgen, !is.na(score))
   numsel = min(nrow(oldmodels), numsel)
@@ -1030,12 +1029,12 @@ add_generation = function(models, numgraphs, numsel, qpgfun, mutfuns, opt_worst_
     map = function(...) furrr::future_map(..., .options = furrr::furrr_options(seed = TRUE))
     imap = function(...) furrr::future_imap(..., .options = furrr::furrr_options(seed = TRUE))
   }
-  if(verbose) alert_info(paste0('Generating new graphs...', space))
+  if(verbose) cli::cli_inform(c(i = 'Generating new graphs...'))
   newmodels %<>% mutate(mutation = names(mutations),
                         igraph = imap(igraph, ~tryCatch(exec(mutations[[.y]], .x), error = function(e) .x)))
-  if(verbose) alert_info(paste0('Evaluating graphs...', space))
+  if(verbose) cli::cli_inform(c(i = 'Evaluating graphs...'))
   newmodels %<>% mutate(out = map(igraph, qpgfun))
-  if(verbose) alert_info(paste0('Attaching to previous generations...', space))
+  if(verbose) cli::cli_inform(c(i = 'Attaching to previous generations...'))
   winners %>%
     mutate(generation = lastgen+1, index = 1:n()) %>%
     bind_rows(newmodels %>% unnest_wider(out))
@@ -1102,12 +1101,11 @@ optimize_admixturegraph_single = function(pops, precomp, mutlist, repnum, numgra
   }
 
   # qpgfun = possibly(qpgfun, otherwise = NULL)
-  space = paste0(paste(rep(' ', 50), collapse=''), '\r')
-  if(verbose) alert_info(paste0('Generate new graphs...', space))
+  if(verbose) cli::cli_inform(c(i = 'Generate new graphs...'))
   if(is.null(initgraphs)) initgraphs = replicate(numgraphs, random_admixturegraph(pops, numadmix, outpop = outpop),
                                                 simplify = FALSE)
   else initgraphs = initgraphs[round(seq(1, length(initgraphs), numgraphs))]
-  if(verbose) alert_info(paste0('Evaluate graphs...', space))
+  if(verbose) cli::cli_inform(c(i = 'Evaluate graphs...'))
   if(parallel) map = function(...) furrr::future_map(..., .options = furrr::furrr_options(seed = TRUE))
   init = tibble(generation=0, index = seq_len(numgraphs),
                 igraph = initgraphs, mutation = 'random_admixturegraph') %>%
@@ -2306,7 +2304,6 @@ reconstruct_from_leafdist = function(leafdist) {
     l = leaves[i]
     ld = leafdist %>% filter(from == l)
     reachable = l
-    cat(paste0(i,'\r'))
     for(j in seq_len(max(ld$dist))) {
       nn = ld %>% filter(dist == j)
       reachable = union(reachable, nn$to)
@@ -3560,7 +3557,7 @@ identifiable_comb = function(graph, edge, jac = NULL, verbose = TRUE) {
   edges = colnames(jac)
 
   for(i in seq_len(length(E(graph)))) {
-    if(verbose) alert_info(paste0(i, '...\r'))
+    if(verbose) cli::cli_inform(c(i = "{i}..."))
     us = identifiable_sets(graph, jac, edge = which(edges == edge), n = i)
     if(edge %in% unlist(us)) break
   }

--- a/R/utility.R
+++ b/R/utility.R
@@ -59,8 +59,12 @@ alert_danger = function(msg) cat(crayon::red(cli::symbol$cross, msg))
 # `cat(file = stderr())`, which is not a message condition. Interactive users
 # who want silence should pass `verbose = FALSE` — that gates the call site
 # unconditionally and works in both modes.
-.heartbeat = function(msg = "", done = FALSE) {
-  if(isatty(stderr())) {
+# `.tty` is a test seam (leading dot — not part of the contract for production
+# callers, which always omit it and let `isatty(stderr())` decide). It exists so
+# tests/testthat/test-heartbeat.R can pin both branches deterministically without
+# OS-level PTY juggling.
+.heartbeat = function(msg = "", done = FALSE, .tty = isatty(stderr())) {
+  if(.tty) {
     if(done) {
       cat("\n", file = stderr())
     } else if(nzchar(msg)) {

--- a/R/utility.R
+++ b/R/utility.R
@@ -20,6 +20,59 @@ alert_warning = function(msg) cat(crayon::yellow('!', msg))
 alert_danger = function(msg) cat(crayon::red(cli::symbol$cross, msg))
 
 
+# Per-iteration progress emit that adapts to its output context.
+#
+# Pre-PR-130, per-iteration progress was emitted with a leading or trailing
+# `\r` (carriage return) to stdout. That overwrote in-place in a terminal but
+# was invisible to orchestrators tailing stderr (`Rscript ... 2>log`).
+# PR #130 routed everything through `cli::cli_inform(c(i = ...))` to fix the
+# tailing case, but as a side-effect each emission became its own scrolling
+# line in interactive sessions — visually painful for loops with thousands of
+# iterations.
+#
+# `.heartbeat()` keeps both use cases working:
+#
+#   * **TTY** (`isatty(stderr())` returns TRUE — interactive R session): writes
+#     `\r<msg>\033[K` to stderr. The CR overwrites the previous line; the
+#     `\033[K` ANSI escape clears from the cursor to end-of-line, so a shorter
+#     follow-up message doesn't leave stale chars from the previous longer one.
+#     No newline — the next emit overwrites it. The loop owner is responsible
+#     for emitting `.heartbeat(done = TRUE)` after the last iteration to print
+#     a trailing newline and advance the cursor past the heartbeat line.
+#
+#   * **Non-TTY** (stderr is a file / pipe / redirect — orchestrator tailing,
+#     CI logs, batch jobs): emits one `cli::cli_inform(c(i = msg))` line per
+#     call. `cli` correctly strips ANSI in non-interactive contexts, so log
+#     consumers see plain UTF-8 with the ℹ bullet and a real `\n` per emit.
+#     `done = TRUE` is a no-op here (no cursor to advance — each line already
+#     ended with `\n`).
+#
+# `msg` supports glue-style `{var}` interpolation, evaluated in the caller's
+# frame via `cli::format_inline`. Same syntax as `cli::cli_inform` so the call
+# sites read the same way in both branches.
+#
+# Caller is expected to gate on `verbose`. The helper itself does not check
+# verbose so the call sites stay locally explicit about when they emit.
+#
+# `suppressMessages()` only silences the non-TTY branch (which routes through
+# the R condition system via `cli::cli_inform`). The TTY branch writes via
+# `cat(file = stderr())`, which is not a message condition. Interactive users
+# who want silence should pass `verbose = FALSE` — that gates the call site
+# unconditionally and works in both modes.
+.heartbeat = function(msg = "", done = FALSE) {
+  if(isatty(stderr())) {
+    if(done) {
+      cat("\n", file = stderr())
+    } else if(nzchar(msg)) {
+      formatted = cli::format_inline(msg, .envir = parent.frame())
+      cat("\r", formatted, "\033[K", file = stderr(), sep = "")
+    }
+  } else if(!done && nzchar(msg)) {
+    cli::cli_inform(c(i = msg), .envir = parent.frame())
+  }
+}
+
+
 gg_color_hue = function(n, l=65, c=100) {
   hues = seq(15, 375, length=n+1)
   grDevices::hcl(h=hues, l=l, c=c)[1:n]
@@ -182,7 +235,7 @@ multistart = function (parmat, fn, args, gr = NULL, lower = -Inf, upper = Inf, m
     # ans = cpp_lbfgsb(parmat[i,], args[[1]], args[[2]], args[[3]], args[[4]], args[[5]], args[[6]], args[[8]])
     # cpp_lbfgsb is ~ 10% faster for large graphs (20 pops, 12 admixnodes), but very similar in speed for smaller ones.
     # only returns 'par' and 'value' at the moment
-    if(verbose) cli::cli_inform(c(i = "{i} of {nset}..."))
+    if(verbose) .heartbeat("{i} of {nset}...")
     tryCatch({
       ans = optim(par = parmat[i, ], fn = fn, gr = gr, lower = lower,
                   upper = upper, method = method, hessian = hessian,
@@ -190,7 +243,7 @@ multistart = function (parmat, fn, args, gr = NULL, lower = -Inf, upper = Inf, m
       ansret[i, ] = c(ans$par, ans$value, ans$counts[1], ans$counts[2], ans$convergence)
     }, error = function(e) {if(!str_detect(e$message, 'constraints are inconsistent')) stop(e)})
   }
-  if(verbose) cat('\n')
+  if(verbose) .heartbeat(done = TRUE)
   if(all(is.na(ansret[,1]))) stop("Optimization unsuccessful (constraints inconsistent). Try increasing 'diag'.")
   as_tibble(ansret, .name_repair = ~c(paste0('p', seq_len(npar)), 'value', 'fevals', 'gevals', 'convergence'))
 }

--- a/R/utility.R
+++ b/R/utility.R
@@ -182,7 +182,7 @@ multistart = function (parmat, fn, args, gr = NULL, lower = -Inf, upper = Inf, m
     # ans = cpp_lbfgsb(parmat[i,], args[[1]], args[[2]], args[[3]], args[[4]], args[[5]], args[[6]], args[[8]])
     # cpp_lbfgsb is ~ 10% faster for large graphs (20 pops, 12 admixnodes), but very similar in speed for smaller ones.
     # only returns 'par' and 'value' at the moment
-    if(verbose) cat(paste0('\r', i, ' out of ', nset, '...'))
+    if(verbose) cli::cli_inform(c(i = "{i} of {nset}..."))
     tryCatch({
       ans = optim(par = parmat[i, ], fn = fn, gr = gr, lower = lower,
                   upper = upper, method = method, hessian = hessian,

--- a/tests/testthat/test-heartbeat.R
+++ b/tests/testthat/test-heartbeat.R
@@ -1,0 +1,135 @@
+# Unit tests for `.heartbeat()` — the TTY-aware progress emitter introduced in
+# PR #130 follow-up. Both branches are pinned at the byte level so a future
+# refactor can't quietly break either contract:
+#
+#   TTY     (`.tty = TRUE`)  → `\r<msg>\033[K` per emit, `\n` on done = TRUE.
+#   Non-TTY (`.tty = FALSE`) → cli `ℹ` message per emit, no-op on done = TRUE.
+#
+# Tests pass `.tty` explicitly so they don't depend on the test runner's actual
+# stderr being (or not being) a terminal. Production call sites always omit
+# `.tty` and let `isatty(stderr())` pick the branch — covered by separate
+# end-to-end dogfood (not regression-tested in CI).
+
+test_that(".heartbeat TTY mode emits \\r<msg>\\033[K bytes per call", {
+  # The canonical in-place pattern: carriage return → message → clear-to-EOL.
+  # `\033[K` (ESC[K) clears from cursor to end-of-line so a shorter follow-up
+  # message doesn't leave stale chars from a longer prior one. Verified at the
+  # byte level — anyone breaking the escape would silently re-introduce the
+  # ghosting bug that the `space = paste0(rep(' ',50)...)` workarounds in
+  # toposearch.R were originally papering over.
+  out = capture.output(.heartbeat("hello", .tty = TRUE), type = "message")
+  expect_length(out, 1)
+  expect_identical(charToRaw(out[1]),
+                   as.raw(c(0x0d, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x1b, 0x5b, 0x4b)))
+})
+
+
+test_that(".heartbeat TTY mode glue-interpolates from caller's frame", {
+  # The helper grabs parent.frame() so call sites can use the same `{var}`
+  # syntax as `cli::cli_inform()`. Tested via a local variable in this frame.
+  i = 7
+  n = 50
+  out = capture.output(.heartbeat("part {i} of {n}", .tty = TRUE),
+                       type = "message")
+  expect_match(out[1], "part 7 of 50", fixed = TRUE)
+  # Still has the \r prefix and \033[K suffix.
+  bytes = charToRaw(out[1])
+  expect_identical(bytes[1], as.raw(0x0d))
+  expect_identical(tail(bytes, 3), as.raw(c(0x1b, 0x5b, 0x4b)))
+})
+
+
+test_that(".heartbeat TTY mode done = TRUE emits a single newline", {
+  # The teardown signal that advances the cursor past the heartbeat line.
+  out = capture.output(.heartbeat(done = TRUE, .tty = TRUE), type = "message")
+  expect_length(out, 1)
+  expect_identical(out[1], "")  # capture.output strips the trailing \n,
+                                # leaving an empty-string element. The fact
+                                # that we got *one* line back (not zero)
+                                # confirms a newline was emitted.
+})
+
+
+test_that(".heartbeat TTY mode is silent when msg is empty and not done", {
+  # Defensive: `nzchar(msg)` guard prevents an unprovoked `\r\033[K` emit
+  # if a caller accidentally passes `""`. We only want to clear the line on
+  # an explicit `done = TRUE` teardown.
+  out = capture.output(.heartbeat("", .tty = TRUE), type = "message")
+  expect_length(out, 0)
+})
+
+
+test_that(".heartbeat TTY mode overwrites in place across successive calls", {
+  # Two emits should produce two `\r<msg>\033[K` cycles back-to-back, with
+  # no intervening newline. In a real terminal the second emit visually
+  # overwrites the first.
+  out = capture.output({
+    .heartbeat("first",  .tty = TRUE)
+    .heartbeat("second", .tty = TRUE)
+  }, type = "message")
+  bytes = charToRaw(paste(out, collapse = ""))
+  # \r first \033[K \r second \033[K
+  expected = c(charToRaw("\rfirst"),  as.raw(c(0x1b, 0x5b, 0x4b)),
+               charToRaw("\rsecond"), as.raw(c(0x1b, 0x5b, 0x4b)))
+  expect_identical(bytes, expected)
+})
+
+
+test_that(".heartbeat non-TTY mode emits a cli ℹ-bulleted message", {
+  # The orchestrator-tail contract: each emit lands on stderr as its own
+  # newline-terminated line, with cli's ℹ bullet (U+2139) and no ANSI
+  # color codes when stderr is not a TTY. cli::cli_inform routes through
+  # `rlang::inform()` so testthat's `capture_messages()` (which hooks the
+  # condition system) catches it.
+  out = testthat::capture_messages(.heartbeat("hello", .tty = FALSE))
+  expect_length(out, 1)
+  # ℹ bullet + space + msg + \n
+  expect_match(out[1], "ℹ hello")
+})
+
+
+test_that(".heartbeat non-TTY mode glue-interpolates from caller's frame", {
+  i = 3
+  n = 10
+  out = testthat::capture_messages(
+    .heartbeat("part {i} of {n}", .tty = FALSE))
+  expect_match(out[1], "part 3 of 10", fixed = TRUE)
+})
+
+
+test_that(".heartbeat non-TTY mode done = TRUE is a silent no-op", {
+  # In non-TTY mode each prior emit was already newline-terminated, so the
+  # teardown has nothing to do. Tested both via the condition system
+  # (capture_messages) and via stderr (capture.output type="message") in
+  # case cli ever changed its emission channel.
+  msgs = testthat::capture_messages(.heartbeat(done = TRUE, .tty = FALSE))
+  expect_length(msgs, 0)
+  raw  = capture.output(.heartbeat(done = TRUE, .tty = FALSE), type = "message")
+  expect_length(raw, 0)
+})
+
+
+test_that(".heartbeat non-TTY mode is silenced by suppressMessages()", {
+  # The cli_inform route emits a `message` condition, which suppressMessages()
+  # catches. This is the documented escape hatch for orchestrator runs that
+  # want a quieter log. The TTY branch uses cat() to stderr which is NOT a
+  # message condition — covered in the next test.
+  out = testthat::capture_messages(
+    suppressMessages(.heartbeat("noisy", .tty = FALSE)))
+  expect_length(out, 0)
+})
+
+
+test_that(".heartbeat TTY mode is NOT silenced by suppressMessages()", {
+  # Documented design choice: TTY users who want silence pass verbose = FALSE
+  # at the call site. `cat(file = stderr())` is not a message condition, so
+  # suppressMessages can't catch it. This test pins that contract — if
+  # someone later "fixes" the TTY branch by routing through message(), they'd
+  # silently regress the in-place overwrite (message() adds its own newline
+  # and prefix, breaking the \r-clear-EOL pattern). The asymmetry is
+  # intentional and tested.
+  out = capture.output(suppressMessages(.heartbeat("loud", .tty = TRUE)),
+                       type = "message")
+  expect_length(out, 1)
+  expect_match(out[1], "loud", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary

Per-iteration `\r` progress emissions (`cat('\r...')`, `alert_info('...\r')`) now go
through `cli::cli_inform(c(i = ...))` — stderr, flushed per call, suppressable via
`suppressMessages()`. The matching `alert_info('\n')` cleanup lines (only needed to
advance the cursor past the overwritten `\r` line) are dropped.

## Why

External orchestrators tailing R's stderr had no heartbeat during `extract_f2()` /
`read_f2()` / `afs_to_f2()` — all per-iteration progress was buffered on stdout behind
`\r` and only flushed at loop end. After this PR, every per-block / per-chunk / per-part
update is its own newline-terminated stderr line.

`cli::cli_inform()` over bare `message()`: same stderr routing (it calls
`rlang::inform()`), but keeps the cyan ℹ-bullet that the package already uses via its
own `alert_info()` helper. `cli` is already in `DESCRIPTION` Imports — no new dep.

## Scope

| File | `\r` sites converted | `'\n'` cleanups dropped |
| --- | --- | --- |
| `R/io.R` | 11 | 7 |
| `R/toposearch.R` | 8 | 0 |
| `R/fstats.R` | 1 | 0 |
| `R/utility.R` | 1 | 0 |
| **Total** | **21** | **7** |

Return values of every touched function are byte-for-byte identical — all changed lines
are pure side-effect emitters. Status banners that don't end in `\r` (once-per-call
announcements like \"Computing block lengths for N SNPs...\") are unchanged.

## Relationship to PR #116

Complementary, not overlapping. #116 added *new* per-chromosome rollup `message()`
emissions inside `f4blockdat_from_geno`. This PR repoints the *existing* `\r` lines
across `fstats.R`, `io.R`, `utility.R`, `toposearch.R`. Together they give a single
stderr stream covering both the per-chromosome summaries and the per-block /
per-chunk / per-part heartbeats.

## Interactive behavior

Each emission is now its own line rather than overwriting in place. For long loops this
scrolls; mute with `suppressMessages()`. The cyan ℹ-bullet survives.

## Test plan

- [x] `R CMD INSTALL` clean
- [x] `testthat`: 335/335 pass (only pre-existing \"no genetic linkage map\" warnings)
- [x] `R CMD check --no-vignettes --no-manual`: `2 WARNINGs, 2 NOTEs`, **identical to
      upstream-master baseline** by diff — no new errors/warnings/notes
- [x] `cli::cli_inform` confirmed to route through `rlang::inform()` to stderr and to be
      silenced by `suppressMessages()`
- [x] End-to-end: `Rscript` with split stdout/stderr — stdout empty, stderr has the
      expected `ℹ part N of N` lines from a `split_mat()` run