### PR TITLE
fix: gate run_shiny_admixtools() on required GUI packages

### DIFF
--- a/R/run_shiny_admixtools.R
+++ b/R/run_shiny_admixtools.R
@@ -7,6 +7,34 @@ run_shiny_admixtools = function() {
   if (appDir == '') {
     stop('Could not find example directory. Try re-installing `admixtools`.', call. = FALSE)
   }
+  # Keep in sync with library() calls in inst/shiny_admixtools/app.R.
+  gui_pkgs = c('DT', 'RColorBrewer', 'htmlwidgets', 'igraph', 'magrittr',
+               'plotly', 'shiny', 'shinyBS', 'shinyFiles', 'shinyWidgets',
+               'shinyalert', 'shinydashboard', 'shinyjs', 'shinythemes',
+               'tidyverse')
+  missing = gui_pkgs[!vapply(gui_pkgs, requireNamespace, logical(1), quietly = TRUE)]
+  if (length(missing) > 0) {
+    install_call = sprintf('install.packages(c(%s))',
+                           paste0('"', missing, '"', collapse = ', '))
+    msg = sprintf('The ADMIXTOOLS 2 GUI needs these packages, which are not installed: %s',
+                  paste(missing, collapse = ', '))
+    if (interactive()) {
+      message(msg)
+      ans = utils::menu(c('Yes', 'No'), title = 'Install them now?')
+      if (ans == 1) {
+        utils::install.packages(missing)
+        still_missing = missing[!vapply(missing, requireNamespace, logical(1), quietly = TRUE)]
+        if (length(still_missing) > 0) {
+          stop(sprintf('Install did not satisfy: %s', paste(still_missing, collapse = ', ')),
+               call. = FALSE)
+        }
+      } else {
+        stop(sprintf('%s\nInstall them with:\n  %s', msg, install_call), call. = FALSE)
+      }
+    } else {
+      stop(sprintf('%s\nInstall them with:\n  %s', msg, install_call), call. = FALSE)
+    }
+  }
   shiny::enableBookmarking('server')
   shiny::runApp(appDir, display.mode = 'normal', launch.browser = TRUE)
 }


### PR DESCRIPTION
## Summary
- Resolves #90: "I cant upload .geno file in GUI mode."
- Root cause: the Shiny app uses \`DT::DTOutput\` / \`DT::renderDataTable\` (and several other \`Suggests:\` packages) unconditionally. When DT is missing, the session crashes on connect with \`Error in loadNamespace(x) : there is no package called 'DT'\`. The browser keeps the static UI but no inputs reach the server, so buttons (including the "Geno file" picker) appear dead.
- Fix: \`run_shiny_admixtools()\` checks for the required GUI packages upfront. In interactive sessions it offers to install missing ones via \`utils::menu()\`; otherwise it stops with the exact \`install.packages(...)\` call.

## Reproduction
1. Install \`admixtools\` in a fresh library (no DT).
2. \`run_shiny_admixtools()\` — UI loads, but the "Geno file" picker's volume dropdown stays empty and clicking buttons does nothing.
3. \`install.packages("DT")\` and re-run — picker populates and the GUI works.

## After this change
- Missing GUI dep, non-interactive: \`stop()\` with the exact \`install.packages(...)\` call.
- Missing GUI dep, interactive: \`message()\` + \`utils::menu()\` prompt to install now.
- All deps present: launches as before.

## Test plan
- [x] All GUI packages installed: launches normally.
- [x] One missing package, non-interactive: stops with \`install.packages(c("<pkg>"))\`.
- [x] One missing package, interactive, user picks Yes: installs and proceeds.
- [x] One missing package, interactive, user picks No: stops with install command.