### PR TITLE
docs(plotting): expand graph-viz section + surface plot_graph_map

### DIFF
--- a/vignettes/plotting.Rmd
+++ b/vignettes/plotting.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Plotting"
 author: "Robert Maier"
-date: "2022-11-12"
+date: "2026-05-21"
 output:
   rmarkdown::html_vignette:
     toc: false
@@ -25,17 +25,45 @@ library(admixtools)
 
 ## Plot admixture graph
 
+The simplest way to visualize an admixture graph is `plot_graph()`, which returns a static `ggplot`:
+
 ```{r}
 plot_graph(example_igraph)
 ```
 
+For an interactive 3D version that's easier to inspect inner-node labels on, use `plotly_graph()`:
 
-<!-- ## Admixture graph on a map -->
+```{r, warning = FALSE}
+plotly_graph(example_igraph)
+```
+
+For an external Graphviz `dot`-rendered version (useful for papers, presentations, or batch rendering pipelines), use `write_dot()`. It supports several display options:
+
+```{r, eval = FALSE}
+# Basic export
+write_dot(example_igraph, "graph.dot")
+
+# Color scheme + label tweaks
+write_dot(example_igraph, "graph.dot",
+          color = FALSE,            # B&W
+          fontsize = 18,            # larger labels
+          hide_weights = TRUE)      # drop the drift-value annotations
+
+# Highlight edges that are not identifiable from the data
+write_dot(example_igraph, "graph.dot",
+          highlight_unidentifiable = TRUE)
+```
+
+See the [data formats vignette](io.html) for the full set of `write_dot()` args and round-tripping with `parse_dot()`.
 
 
-<!-- ```{r, fig.height = 7, fig.align='center'} -->
-<!-- plot_graph_map(example_igraph, example_anno) -->
-<!-- ``` -->
+## Admixture graph on a map
+
+`plot_graph_map()` overlays the graph on a geographic map, using per-individual coordinates (e.g., from `example_anno`) to place leaf nodes. It returns an interactive 3D plotly widget — best explored interactively rather than as a static screenshot:
+
+```{r, eval = FALSE}
+plot_graph_map(example_igraph, example_anno)
+```
 
 
 ## All samples on a map


### PR DESCRIPTION
## Summary

Three content changes to `vignettes/plotting.Rmd`.

* **`## Plot admixture graph` augmented with `plotly_graph` + `write_dot`**: the previous version only documented `plot_graph()`. Adds the interactive `plotly_graph()` (already used elsewhere in vignettes but never introduced here) and `write_dot()` for Graphviz-based external rendering. The `write_dot` examples cover the most-likely-used args from #122 (`color`, `fontsize`, `hide_weights`, `highlight_unidentifiable`); cross-link to `io.html` covers the rest and round-tripping with `parse_dot()`.

* **`## Admixture graph on a map` uncommented but with `eval = FALSE`**: the previous version had this section `<!-- -->`-wrapped. Verified `plot_graph_map(example_igraph, example_anno)` works correctly but produces a poor static screenshot (3D plotly widget — the rendered image shows just a legend and a tiny map silhouette, no visible graph). Set `eval = FALSE` and added prose noting the widget is best explored interactively. Users gain discoverability of the function without the vignette shipping a confusing static image.

* **Date bumped** to `2026-05-21`; author retained as Robert.

## Test plan

* [x] Renders to HTML via `rmarkdown::render` (~4 MB output — adds one plotly bundle from `plotly_graph()` vs the original).
* [x] Visual review of rendered HTML caught the `plot_graph_map` static-render issue; my initial proposal to set `eval = TRUE` was revised to `eval = FALSE` based on visual evidence.
* [x] All function references exist in current NAMESPACE: `plot_graph`, `plotly_graph`, `write_dot`, `plot_graph_map`, `plot_map`, `parse_dot`.
* [x] Cross-link to `io.html` uses same convention as the data formats vignette.

## What's not changed

The `## All samples on a map` section (using `plot_map(example_anno, map_layout = 2)`) is untouched — the existing satellite-map rendering is excellent.