### PR TITLE
fix(plotly_comparison): increase bottom margin so x-axis title isn't clipped

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -40,7 +40,7 @@ plotly_comparison = function(out1, out2, name1 = NULL, name2 = NULL) {
   if(is.null(name1)) name1 = enexpr(out1)
   if(is.null(name2)) name2 = enexpr(out2)
   p = plot_comparison(out1, out2, name1 = name1, name2 = name2)
-  plotly::ggplotly(p)
+  plotly::ggplotly(p) %>% plotly::layout(margin = list(b = 80))
 }
 
 


### PR DESCRIPTION
## Summary

When `plotly_comparison()` is rendered into the `admixtools` vignette (the `plotly_comparison(qpg_results, qpg_results2)` chunk near the bottom of `vignettes/admixtools.Rmd`), the long x-axis title — e.g. `qpg_results (score: 19219.98)` — has its descender pixels clipped by ~5 px at the bottom of the SVG. plotly's auto-layout reserves a fixed-proportion bottom margin that's slightly too small for this text, and the SVG's `overflow:hidden` cuts it off. Adjusting `fig.height` / `out.height` in the chunk options doesn't help because the margin is set in proportional units inside the plotly object.

This patches `plotly_comparison()` to pipe `plotly::ggplotly(p)` through `plotly::layout(margin = list(b = 80))`, which reserves enough vertical room for the title and its descenders.

```diff
-  plotly::ggplotly(p)
+  plotly::ggplotly(p) %>% plotly::layout(margin = list(b = 80))
```

80 px is a starting value that comfortably fits the title text seen in the vignette example; happy to tune up or down if a different value looks better with your test data.

## Test plan

- [ ] Re-render `vignettes/admixtools.Rmd` and confirm the x-axis title in the `plotly_comparison(qpg_results, qpg_results2)` chunk shows full descenders (no clipping at the SVG bottom edge).
- [ ] Spot-check other `plotly_comparison()` usages — the larger bottom margin should be visually neutral when titles are short.