### PR TITLE
test(fixtures): silence incidental no-linkage-map warnings in cache_id tests

### DIFF
--- a/tests/testthat/helper-pfile.R
+++ b/tests/testthat/helper-pfile.R
@@ -181,6 +181,23 @@ build_pfile_fixture = function(dir, with_multi = FALSE, with_fid = TRUE,
       txt[body_idx] = sapply(body, paste, collapse = "\t")
       writeLines(txt, pvar_path)
     }
+
+    # Also inject non-zero CM into the .bim (column 3). plink2 ships .bim
+    # with CM=0 for every variant; tests that read the .bim via plink_to_afs
+    # would otherwise hit get_block_lengths()'s "No genetic linkage map
+    # found!" warning even when this flag is on. Same POS/1e6 rate as .pvar
+    # so the two formats stay consistent for cross-format equivalence tests.
+    if(!is.na(bed_pref)) {
+      bim_path = paste0(bed_pref, ".bim")
+      if(file.exists(bim_path)) {
+        bim = read.table(bim_path, header = FALSE, sep = "\t",
+                         stringsAsFactors = FALSE,
+                         col.names = c("CHR", "SNP", "CM", "POS", "A1", "A2"))
+        bim$CM = bim$POS / 1e6
+        write.table(bim, bim_path, sep = "\t", quote = FALSE,
+                    row.names = FALSE, col.names = FALSE)
+      }
+    }
   }
 
   list(pfile_pref = pfile_pref,

--- a/tests/testthat/test-compute_f2_cache_id.R
+++ b/tests/testthat/test-compute_f2_cache_id.R
@@ -188,14 +188,26 @@ test_that("compute_f2_cache_id propagates get_block_lengths errors instead of re
     testthat::skip_if(is.na(pref), "BED fixture unavailable")
 
     # Hand-crafted snpfile missing the CHR column required by get_block_lengths.
-    # suppressWarnings: the malformed input also surfaces an incidental
-    # "no linkage map" warning before the SUT error fires; we only care that
-    # the error propagates.
+    # Mute only the predictable scaffolding noise that the malformed input
+    # provokes BEFORE the SUT error fires: tibble's "Unknown or uninitialised
+    # column" warnings on `$CHR` / `$cm` access (deliberately absent in
+    # bad_snp), and the pre-error "No genetic linkage map" warning from
+    # get_block_lengths(). Anything else surfaces — narrower than blanket
+    # `suppressWarnings()` so a future-added real warning in this code path
+    # doesn't silently hide.
     bad_snp = tibble::tibble(POS = 1:10, A1 = "A", A2 = "G")
+    expected_noise = c("No genetic linkage map",
+                       "Unknown or uninitialised column")
+    mute_expected = function(w) {
+      msg = conditionMessage(w)
+      if(any(vapply(expected_noise, grepl, logical(1), msg)))
+        invokeRestart("muffleWarning")
+    }
     expect_error(
-      suppressWarnings(
+      withCallingHandlers(
         compute_f2_cache_id(pref, format = "plink", pops = fix$fid_pops,
-                            snpfile_kept = bad_snp, blgsize = 0.05)))
+                            snpfile_kept = bad_snp, blgsize = 0.05),
+        warning = mute_expected))
   })
 })
 

--- a/tests/testthat/test-compute_f2_cache_id.R
+++ b/tests/testthat/test-compute_f2_cache_id.R
@@ -30,8 +30,11 @@ test_that("compute_f2_cache_id changes when the IID subset changes", {
   # different cache ids. Mode-1 direct call avoids extract_f2's "informative
   # SNPs" requirement (which can't be met with a 3-sample-per-pop fixture
   # restricted to one pop).
+  # `with_cm_col = TRUE` populates a synthetic CM column in the fixture so
+  # get_block_lengths takes the cm-distance path rather than warning about a
+  # missing linkage map (incidental to this test's SUT).
   withr::with_tempdir({
-    fix = build_pfile_fixture(getwd(), with_fid = TRUE)
+    fix = build_pfile_fixture(getwd(), with_fid = TRUE, with_cm_col = TRUE)
     pref = fix$bed_pref
     testthat::skip_if(is.na(pref), "BED fixture unavailable")
 
@@ -55,8 +58,10 @@ test_that("compute_f2_cache_id changes when the IID subset changes", {
 test_that("compute_f2_cache_id changes when the variant set changes", {
   # Same IIDs, perturb one variant tuple, cache id must change. Direct
   # mode-1 call so we can control snpfile_kept precisely.
+  # `with_cm_col = TRUE` silences the incidental no-linkage-map warning
+  # (see notes on the IID-subset test above).
   withr::with_tempdir({
-    fix = build_pfile_fixture(getwd(), with_fid = TRUE)
+    fix = build_pfile_fixture(getwd(), with_fid = TRUE, with_cm_col = TRUE)
     pref = fix$bed_pref
     testthat::skip_if(is.na(pref), "BED fixture unavailable")
 
@@ -119,7 +124,7 @@ test_that("FID-less PFILE: compute_f2_cache_id delegates to .read_psam (issue 1)
   #      proving the helper is actually wired in (not just the column
   #      detection bypassed).
   withr::with_tempdir({
-    fix = build_pfile_fixture(getwd(), with_fid = FALSE)
+    fix = build_pfile_fixture(getwd(), with_fid = FALSE, with_cm_col = TRUE)
     pref = fix$pfile_pref
 
     afdat = suppressMessages(suppressWarnings(pfile_to_afs(pref)))
@@ -155,7 +160,7 @@ test_that("PFILE .pvar parses through compute_f2_cache_id without read_table err
   # this guards against is "any read of .pvar via read_table inside the
   # cache-id codepath".
   withr::with_tempdir({
-    fix = build_pfile_fixture(getwd(), with_fid = TRUE)
+    fix = build_pfile_fixture(getwd(), with_fid = TRUE, with_cm_col = TRUE)
     pref = fix$pfile_pref
 
     # Direct .read_pvar usage (the helper now wired into the qpfstats branch):
@@ -183,10 +188,14 @@ test_that("compute_f2_cache_id propagates get_block_lengths errors instead of re
     testthat::skip_if(is.na(pref), "BED fixture unavailable")
 
     # Hand-crafted snpfile missing the CHR column required by get_block_lengths.
+    # suppressWarnings: the malformed input also surfaces an incidental
+    # "no linkage map" warning before the SUT error fires; we only care that
+    # the error propagates.
     bad_snp = tibble::tibble(POS = 1:10, A1 = "A", A2 = "G")
     expect_error(
-      compute_f2_cache_id(pref, format = "plink", pops = fix$fid_pops,
-                          snpfile_kept = bad_snp, blgsize = 0.05))
+      suppressWarnings(
+        compute_f2_cache_id(pref, format = "plink", pops = fix$fid_pops,
+                            snpfile_kept = bad_snp, blgsize = 0.05)))
   })
 })
 
@@ -202,7 +211,7 @@ test_that("compute_f2_cache_id auto-detects PFILE when only .pvar.zst is present
   # the .pvar.zst fixture from the helper's .pvar output).
   testthat::skip_if(Sys.which("zstd") == "", "zstd CLI not on PATH")
   withr::with_tempdir({
-    fix = build_pfile_fixture(getwd(), with_fid = TRUE)
+    fix = build_pfile_fixture(getwd(), with_fid = TRUE, with_cm_col = TRUE)
     pref = fix$pfile_pref
     testthat::skip_if(is.na(pref), "PFILE fixture unavailable")
 


### PR DESCRIPTION
## Summary

Silences the 11 testthat runtime warnings emitted by `test-compute_f2_cache_id.R`. All are package-correct `get_block_lengths()` warnings ("No genetic linkage map found! Defining blocks by base pair distance of 2e+06") that fire because the test fixtures intentionally lack CM data. The warning is real and useful for production users; it's just noise here.

## What changed

- `build_pfile_fixture(with_cm_col = TRUE)` previously only injected synthetic CM into the `.pvar` header. **Now also rewrites the `.bim`'s CM column** (column 3) with the same `POS / 1e6` rate, so tests using the BED-format prefix (`fix$bed_pref` → `plink_to_afs` reads the `.bim`) finally see non-zero CM data.

- Five tests that hit the warning as incidental noise now pass `with_cm_col = TRUE` to the fixture builder:
  - `compute_f2_cache_id changes when the IID subset changes`
  - `compute_f2_cache_id changes when the variant set changes`
  - `FID-less PFILE: compute_f2_cache_id delegates to .read_psam (issue 1)`
  - `PFILE .pvar parses through compute_f2_cache_id without read_table errors (issue 2)`
  - `compute_f2_cache_id auto-detects PFILE when only .pvar.zst is present`

- The sixth test (`compute_f2_cache_id propagates get_block_lengths errors instead of returning a bogus hash (issue 3)`) deliberately uses a hand-crafted snpfile missing the CHR column to exercise error propagation. The no-linkage-map warning is incidental to its SUT (the error path), so the call is wrapped in `suppressWarnings()` with an explanatory comment.

## Test plan

- [x] `testthat::test_dir`: previously 11 warnings, now **0 warnings**, all 493 expectations pass
- [x] No test semantics changed — all assertions are pattern (`^sha256:...$`) or relative (`expect_false(identical(...))`), not absolute cache_id values
- [x] No production code touched (only `tests/testthat/`)