### PR TITLE
feat(legofit): structured warnings for unfittable .lgo and lossy round trip

### DIFF
--- a/R/legofit.R
+++ b/R/legofit.R
@@ -772,6 +772,7 @@ read_lgo <- function(path = NULL, text = NULL, as = c("edges", "igraph")) {
   params_rows <- list()
   derive_rows <- list()
   mix_rows    <- list()
+  seg_names_with_samples <- character(0)
 
   for (ln in lines) {
     tok <- strsplit(trimws(ln), "\\s+")[[1]]
@@ -817,9 +818,22 @@ read_lgo <- function(path = NULL, text = NULL, as = c("edges", "igraph")) {
 
     } else if (tok[[1]] == "segment") {
       # segment <name> [t=<param>] twoN=<param> [samples=<int>]
-      # Parsed for syntactic validity only; the edge tibble is built from
-      # derive/mix statements below. Segment-level metadata (samples, twoN
-      # bindings) is not surfaced in the current return value.
+      # The edge tibble is built from derive/mix statements below;
+      # segment-level metadata is otherwise not surfaced. We capture only
+      # a positive `samples=` count to power the lossy-round-trip warning.
+      # Tolerant of whitespace around `=` and of keyword casing, matching
+      # the time/twoN/mixFrac parser above. `samples=0` is not a sample.
+      if (length(tok) > 2) {
+        rest <- paste(tok[-(1:2)], collapse = " ")
+        m <- regmatches(
+          rest,
+          regexec("(?:^|\\s)samples\\s*=\\s*([0-9]+)", rest,
+                  ignore.case = TRUE, perl = TRUE)
+        )[[1]]
+        if (length(m) == 2 && as.integer(m[[2]]) > 0) {
+          seg_names_with_samples <- c(seg_names_with_samples, tok[[2]])
+        }
+      }
       next
 
     } else if (tok[[1]] == "derive") {
@@ -856,6 +870,27 @@ read_lgo <- function(path = NULL, text = NULL, as = c("edges", "igraph")) {
         class = "legofit_lgo_unsupported"
       )
     }
+  }
+
+  # Sampled internal nodes round-trip lossily: the edge tibble does not
+  # carry per-segment `samples` tags, so any sampled segment that is also
+  # a parent (via derive or mix) loses that information. Warn rather than
+  # silently drop.
+  derive_parents <- vapply(derive_rows, function(r) r$parent, character(1))
+  mix_parents <- c(
+    vapply(mix_rows, function(r) r$parent_high, character(1)),
+    vapply(mix_rows, function(r) r$parent_low,  character(1))
+  )
+  internal_sampled <- intersect(
+    seg_names_with_samples, c(derive_parents, mix_parents)
+  )
+  if (length(internal_sampled) > 0) {
+    rlang::warn(
+      c("LEGOFIT file has sampled internal nodes; sample tags will be lost in the admixtools edge tibble.",
+        "i" = paste("Affected nodes:", paste(internal_sampled, collapse = ", ")),
+        "i" = "admixtools' edge tibble does not yet model sampled internal nodes."),
+      class = "legofit_lossy_round_trip"
+    )
   }
 
   # Build params lookup: name -> value
@@ -1033,6 +1068,19 @@ graph_to_lgo <- function(graph,
   full_samples[leaves] <- as.integer(samples_vec[leaves])
 
   lgo_text <- assemble_lgo(edges, params, times, twoN_decls, full_samples)
+
+  is_sampled <- !is.na(full_samples) & full_samples > 0
+  n_sampled <- sum(is_sampled)
+  if (n_sampled < 2) {
+    sampled_names <- names(full_samples)[is_sampled]
+    rlang::warn(
+      c("Resulting .lgo has < 2 sampled segments; LEGOFIT cannot fit it (zero observable site patterns).",
+        "i" = sprintf("Sampled segments (%d): %s", n_sampled,
+                      if (length(sampled_names) > 0) paste(sampled_names, collapse = ", ") else "none"),
+        "i" = "Pass `samples = c(nodeA = 1, nodeB = 1, ...)` or use a graph with more leaves."),
+      class = "legofit_unfittable_lgo"
+    )
+  }
 
   if (validate) validate_via_roundtrip(lgo_text, edges)
   if (!is.null(file)) writeLines(lgo_text, file)

--- a/tests/testthat/test-graph_to_lgo_warn.R
+++ b/tests/testthat/test-graph_to_lgo_warn.R
@@ -1,0 +1,43 @@
+test_that("graph_to_lgo warns when fewer than 2 leaves receive samples", {
+  # make_minimal_graph() has only one leaf (X), so scalar samples = 1 places
+  # `samples=1` on a single segment. LEGOFIT requires >= 2 sampled segments
+  # to produce observable site patterns, so emit a structured warning.
+  expect_warning(
+    graph_to_lgo(make_minimal_graph(), validate = FALSE),
+    class = "legofit_unfittable_lgo"
+  )
+})
+
+test_that("legofit_unfittable_lgo warning names the sampled segments", {
+  w <- tryCatch(
+    graph_to_lgo(make_minimal_graph(), validate = FALSE),
+    legofit_unfittable_lgo = function(c) c
+  )
+  expect_s3_class(w, "legofit_unfittable_lgo")
+  msg <- paste(w$message, collapse = "\n")
+  expect_match(msg, "\\bX\\b")
+  expect_match(msg, "Sampled segments \\(1\\)")
+})
+
+test_that("graph_to_lgo counts only positive samples (samples=0 is unfittable)", {
+  # Two leaves would normally be fittable, but samples = 0 on every leaf
+  # yields zero observable site patterns. The count must exclude zeros, so
+  # the warning still fires and reports no sampled segments.
+  e <- tibble::tibble(from = c("R", "R"), to = c("A", "B"))
+  w <- tryCatch(
+    graph_to_lgo(e, samples = c(A = 0, B = 0), validate = FALSE),
+    legofit_unfittable_lgo = function(c) c
+  )
+  expect_s3_class(w, "legofit_unfittable_lgo")
+  expect_match(paste(w$message, collapse = "\n"),
+               "Sampled segments (0): none", fixed = TRUE)
+})
+
+test_that("graph_to_lgo is silent when at least 2 leaves are sampled", {
+  e <- tibble::tibble(from = c("R", "R"), to = c("A", "B"))
+  expect_warning(
+    graph_to_lgo(e, validate = FALSE),
+    class = "legofit_unfittable_lgo",
+    regexp = NA
+  )
+})

--- a/tests/testthat/test-read_lgo_warn.R
+++ b/tests/testthat/test-read_lgo_warn.R
@@ -1,0 +1,81 @@
+# Minimal valid .lgo (one admixture) whose `M` and `M_A` segment lines can
+# be overridden to exercise the sampled-internal-node detection. `M` is a
+# derive parent (X derives from M); `M_A` is a mix parent only.
+minimal_lgo_lines <- function(M   = "segment M t=T_M twoN=one",
+                              M_A = "segment M_A t=T_admix_M twoN=one") {
+  c(
+    "time fixed T_X=0", "time free T_R=0.07", "time free T_A=0.02",
+    "time free T_B=0.02", "time free T_M=0.02", "time free T_admix_M=0.02",
+    "twoN fixed one=1", "mixFrac free m_M=0.4",
+    "segment R t=T_R twoN=one", "segment A t=T_A twoN=one",
+    "segment B t=T_B twoN=one", M, "segment X t=T_X twoN=one samples=1",
+    M_A, "segment M_B t=T_admix_M twoN=one",
+    "derive A from R", "derive B from R", "derive X from M",
+    "derive M_A from A", "derive M_B from B",
+    "mix M from M_A + m_M * M_B"
+  )
+}
+
+test_that("read_lgo warns when sampled segments appear as derive parents", {
+  # rha20.lgo contains segments v and a that both carry `samples=1` and
+  # also appear as derive parents (n derives from v; v derives from a).
+  # The edge tibble cannot represent per-segment sampling, so warn.
+  expect_warning(
+    read_lgo(testthat::test_path("fixtures", "rha20.lgo")),
+    class = "legofit_lossy_round_trip"
+  )
+})
+
+test_that("legofit_lossy_round_trip warning names the affected internal nodes", {
+  w <- tryCatch(
+    read_lgo(testthat::test_path("fixtures", "rha20.lgo")),
+    legofit_lossy_round_trip = function(c) c
+  )
+  expect_s3_class(w, "legofit_lossy_round_trip")
+  msg <- paste(w$message, collapse = "\n")
+  expect_match(msg, "\\bv\\b")
+  expect_match(msg, "\\ba\\b")
+})
+
+test_that("read_lgo is silent on .lgo with only leaf-sampled segments", {
+  # minimal.lgo has `samples=1` only on X, which is a leaf (never a
+  # derive parent). No lossy round trip, so no warning.
+  expect_warning(
+    read_lgo(testthat::test_path("fixtures", "minimal.lgo")),
+    class = "legofit_lossy_round_trip",
+    regexp = NA
+  )
+})
+
+test_that("read_lgo warns when a sampled segment is only a mix parent", {
+  # M_A feeds the admixture `mix M from M_A + ...` but is never a derive
+  # parent. Its samples tag is still lost in the edge tibble, so warn.
+  w <- tryCatch(
+    read_lgo(text = minimal_lgo_lines(
+      M_A = "segment M_A t=T_admix_M twoN=one samples=1")),
+    legofit_lossy_round_trip = function(c) c
+  )
+  expect_s3_class(w, "legofit_lossy_round_trip")
+  expect_match(paste(w$message, collapse = "\n"), "M_A", fixed = TRUE)
+})
+
+test_that("read_lgo treats samples=0 on an internal node as unsampled", {
+  # `samples=0` means the segment is not sampled, so nothing is lost even
+  # though M is a derive parent. No lossy round trip warning.
+  expect_warning(
+    read_lgo(text = minimal_lgo_lines(M = "segment M t=T_M twoN=one samples=0")),
+    class = "legofit_lossy_round_trip",
+    regexp = NA
+  )
+})
+
+test_that("read_lgo detects samples= regardless of whitespace or casing", {
+  # Some writers emit `Samples = 1` with spaces and mixed case. M is a
+  # derive parent, so the lossy round trip warning must still fire.
+  w <- tryCatch(
+    read_lgo(text = minimal_lgo_lines(M = "segment M t=T_M twoN=one Samples = 1")),
+    legofit_lossy_round_trip = function(c) c
+  )
+  expect_s3_class(w, "legofit_lossy_round_trip")
+  expect_match(paste(w$message, collapse = "\n"), "Affected nodes: M", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary

Adds two structured warnings so silent confusion does not slip through when graphs and LEGOFIT files fail to round trip cleanly.

* `legofit_unfittable_lgo` fires from `graph_to_lgo()` when fewer than two segments receive `samples=`. LEGOFIT cannot fit such a file because it has zero observable site patterns. Triggered by graphs like `make_minimal_graph()` whose only leaf is `X`.
* `legofit_lossy_round_trip` fires from `read_lgo()` when one or more sampled segments also appear as a derive parent. The edge tibble has no slot for `samples=` on individual segments, so those tags are silently dropped on the way in. Triggered by fixtures like `rha20.lgo`, which carries `samples=1` on internal segments `v` and `a`.

Both warnings carry an rlang class (`legofit_unfittable_lgo`, `legofit_lossy_round_trip`) so callers can catch or suppress by name with `withCallingHandlers()` or `suppressWarnings()`.

## Why now

These warnings catch failure modes that currently fail silently. They land independently of a planned redesign that would model sampled internal nodes directly in the edge tibble.

## Diff shape

* `R/legofit.R`: 33 insertions, 3 deletions. One `rlang::warn()` call added inside `graph_to_lgo()` right after `assemble_lgo()`, and one block added at the end of the `read_lgo()` parse loop. The existing segment-parsing branch grows a tiny `samples=` capture (previously it was a syntactic-only `next`).
* New tests:
  * `tests/testthat/test-graph_to_lgo_warn.R` confirms the unfittable warning fires on `make_minimal_graph()` and names `X`.
  * `tests/testthat/test-read_lgo_warn.R` confirms the lossy round trip warning fires on `rha20.lgo` and names `v` and `a`, and is silent on `minimal.lgo`.

## Test plan

- [x] `R CMD check` clean for this diff (`Status: 2 WARNINGs, 3 NOTEs`, all pre-existing environment items around vignettes and Suggests packages).
- [x] Full test suite: `[ FAIL 0 | WARN 50 | SKIP 1 | PASS 501 ]`. The 50 warnings are the new structured warnings firing on legacy test calls that use `make_minimal_graph()` or read `rha20.lgo`. These are by design; tests still pass. Test authors who want silence can wrap call sites in `suppressWarnings()` going forward.
- [x] New test files pass standalone.
