### PR TITLE
test(legofit): expect the unfittable lgo warning instead of letting it print

### DIFF
--- a/tests/testthat/test-functional.R
+++ b/tests/testthat/test-functional.R
@@ -157,28 +157,33 @@ test_that("T1.1: qpgraph(example_igraph) round-trips via time_handling='free'", 
 test_that("T1.2: time_handling='init' produces minimal-init.lgo verbatim", {
   g <- make_minimal_graph()
   g$time <- c(0.05, 0.05, 0, 0, 0.02)  # admix edges zeroed for consistency
-  txt <- graph_to_lgo(g, time_handling = "init", validate = FALSE)
+  expect_warning(txt <- graph_to_lgo(g, time_handling = "init", validate = FALSE),
+                 class = "legofit_unfittable_lgo")
   expected <- readLines(testthat::test_path("fixtures", "minimal-init.lgo"))
   expect_equal(strsplit(txt, "\n", fixed = TRUE)[[1]], expected)
 })
 
 test_that("T1.2: time_handling='free' produces minimal-free.lgo verbatim", {
-  txt <- graph_to_lgo(make_minimal_graph(), time_handling = "free",
-                       validate = FALSE)
+  expect_warning(
+    txt <- graph_to_lgo(make_minimal_graph(), time_handling = "free", validate = FALSE),
+    class = "legofit_unfittable_lgo"
+  )
   expected <- readLines(testthat::test_path("fixtures", "minimal-free.lgo"))
   expect_equal(strsplit(txt, "\n", fixed = TRUE)[[1]], expected)
 })
 
 # T1.3 ------------------------------------------------------------------
 test_that("T1.3: twoN=scalar produces minimal-twoN-scalar.lgo verbatim", {
-  txt <- graph_to_lgo(make_minimal_graph(), twoN = 1000, validate = FALSE)
+  expect_warning(txt <- graph_to_lgo(make_minimal_graph(), twoN = 1000, validate = FALSE),
+                 class = "legofit_unfittable_lgo")
   expected <- readLines(testthat::test_path("fixtures", "minimal-twoN-scalar.lgo"))
   expect_equal(strsplit(txt, "\n", fixed = TRUE)[[1]], expected)
 })
 
 test_that("T1.3: twoN=named-vector produces minimal-twoN-named.lgo verbatim", {
   twoN_named <- c(R = 10000, A = 5000, B = 5000, M = 5000, X = 1000)
-  txt <- graph_to_lgo(make_minimal_graph(), twoN = twoN_named, validate = FALSE)
+  expect_warning(txt <- graph_to_lgo(make_minimal_graph(), twoN = twoN_named, validate = FALSE),
+                 class = "legofit_unfittable_lgo")
   expected <- readLines(testthat::test_path("fixtures", "minimal-twoN-named.lgo"))
   expect_equal(strsplit(txt, "\n", fixed = TRUE)[[1]], expected)
 })
@@ -186,7 +191,8 @@ test_that("T1.3: twoN=named-vector produces minimal-twoN-named.lgo verbatim", {
 # T1.5 ------------------------------------------------------------------
 test_that("T1.5: outpop is fully stripped from the output", {
   g <- make_minimal_graph_with_outgroup()
-  txt <- graph_to_lgo(g, outpop = "Outgroup", validate = TRUE)
+  expect_warning(txt <- graph_to_lgo(g, outpop = "Outgroup", validate = TRUE),
+                 class = "legofit_unfittable_lgo")
 
   # No segment, derive, or mix should reference Outgroup
   expect_false(grepl("Outgroup", txt))
@@ -208,11 +214,14 @@ test_that("T1.6: custom drift_to_time function scales output times", {
   g$time <- c(0.05, 0.05, 0, 0, 0.02)  # admix edges zeroed
 
   scale <- 1000
-  txt_scaled <- graph_to_lgo(
-    g,
-    time_handling = "init",
-    drift_to_time = function(d, s) d * scale,
-    validate = FALSE
+  expect_warning(
+    txt_scaled <- graph_to_lgo(
+      g,
+      time_handling = "init",
+      drift_to_time = function(d, s) d * scale,
+      validate = FALSE
+    ),
+    class = "legofit_unfittable_lgo"
   )
 
   # Note: when `time` column is present and non-NA, compute_times uses
@@ -229,11 +238,14 @@ test_that("T1.6: custom drift_to_time function scales output times", {
     "A",   "B", "normal", 0.03,
     "B",   "C", "normal", 0.02
   )
-  txt_tree <- graph_to_lgo(
-    tree,
-    time_handling = "init",
-    drift_to_time = function(d, s) d * scale,
-    validate = FALSE
+  expect_warning(
+    txt_tree <- graph_to_lgo(
+      tree,
+      time_handling = "init",
+      drift_to_time = function(d, s) d * scale,
+      validate = FALSE
+    ),
+    class = "legofit_unfittable_lgo"
   )
   # Tree: C=0, B=0.02*1000=20, A=20+0.03*1000=50, R=50+0.05*1000=100
   expect_match(txt_tree, "T_R=100")
@@ -255,10 +267,13 @@ test_that("T1.6: drift_to_time receives correct segment_vec argument", {
     if (length(s) != length(d)) stop("length mismatch")
     d
   }
-  expect_no_error(
-    graph_to_lgo(tree, time_handling = "init",
-                 drift_to_time = picky_drift_to_time,
-                 validate = FALSE)
+  expect_warning(
+    expect_no_error(
+      graph_to_lgo(tree, time_handling = "init",
+                   drift_to_time = picky_drift_to_time,
+                   validate = FALSE)
+    ),
+    class = "legofit_unfittable_lgo"
   )
 })
 
@@ -278,13 +293,16 @@ test_that("T1.7: read_lgo handles a 100-node graph in under 500ms", {
 # T1.8 ------------------------------------------------------------------
 test_that("T1.8: graph_to_lgo output is deterministic across runs", {
   g <- make_minimal_graph()
-  outputs <- replicate(10, graph_to_lgo(g))
+  # minimal graph is unfittable (one leaf), so each call warns; we test
+  # determinism here, not the warning, so suppress the expected noise
+  outputs <- suppressWarnings(replicate(10, graph_to_lgo(g)))
   expect_length(unique(outputs), 1)
 })
 
 test_that("T1.8: graph_to_lgo output is deterministic for igraph input", {
   ig <- make_minimal_igraph()
-  outputs <- replicate(10, graph_to_lgo(ig))
+  # same expected warning as the determinism test for edge tibble input
+  outputs <- suppressWarnings(replicate(10, graph_to_lgo(ig)))
   expect_length(unique(outputs), 1)
 })
 
@@ -295,7 +313,12 @@ test_that("T1.8: graph_to_lgo output is deterministic for igraph input", {
 # around `=`, multi-line param declarations, and `time constrained`
 # arithmetic expressions evaluated safely against earlier params.
 test_that("T2.3: read_lgo parses rha20.lgo (constrained expressions evaluated)", {
-  result <- read_lgo(path = test_path("fixtures", "rha20.lgo"))
+  # rha20.lgo samples internal nodes (v, a), so read_lgo warns about a
+  # lossy round trip; that is expected for this fixture
+  expect_warning(
+    result <- read_lgo(path = test_path("fixtures", "rha20.lgo")),
+    class = "legofit_lossy_round_trip"
+  )
   expect_s3_class(result, "tbl_df")
   expect_setequal(names(result), c("from", "to", "type", "weight"))
   # rha20 collapses to: 5 normal edges + 8 admix edges = 13 total

--- a/tests/testthat/test-functional.R
+++ b/tests/testthat/test-functional.R
@@ -215,7 +215,7 @@ test_that("T1.6: custom drift_to_time function scales output times", {
 
   scale <- 1000
   expect_warning(
-    txt_scaled <- graph_to_lgo(
+    graph_to_lgo(
       g,
       time_handling = "init",
       drift_to_time = function(d, s) d * scale,

--- a/tests/testthat/test-graph_to_lgo.R
+++ b/tests/testthat/test-graph_to_lgo.R
@@ -8,7 +8,7 @@ test_that("graph_to_lgo errors when samples named-vector has unknown leaf names"
 
 test_that("graph_to_lgo igraph input produces byte-identical output to golden", {
   ig      <- make_minimal_igraph()
-  txt     <- graph_to_lgo(ig)
+  expect_warning(txt <- graph_to_lgo(ig), class = "legofit_unfittable_lgo")
   golden  <- readLines(testthat::test_path("fixtures", "minimal.lgo"))
   expect_equal(strsplit(txt, "\n", fixed = TRUE)[[1]], golden)
 })


### PR DESCRIPTION
## What

The minimal graph fixture used across the legofit tests has a single sampled leaf, so `graph_to_lgo()` emits the intentional `legofit_unfittable_lgo` warning (added in #146). Several functional tests and the byte identical golden test tripped it about 29 times, which showed up as WARN noise in the testthat output. Those tests assert output format and determinism, not fittability, so the warning is incidental to what they check.

## Change

Test hygiene only. No package source changes.

- Wrap each single `graph_to_lgo()` call on the minimal fixture in `expect_warning(class = "legofit_unfittable_lgo")`, keeping the existing assertions on the returned text. This silences the noise and documents the expected behavior without masking other warnings.
- Use `suppressWarnings()` around the two `replicate()` determinism loops, where the point is determinism rather than the warning.
- Expect the `legofit_lossy_round_trip` warning that `read_lgo()` emits when parsing `rha20.lgo`, since that fixture samples internal nodes (v, a) by design.

## Verification

`R CMD INSTALL --no-docs .` then `testthat::test_dir('tests/testthat', package='admixtools')`.

Before this change the suite printed 30 of these warnings (29 unfittable plus 1 lossy round trip). After it prints none, with no failures, and the new `expect_warning()` calls add 10 passing assertions.

```
Before   FAIL 0 | WARN 30 | SKIP 1 | PASS 605
After    FAIL 0 | WARN 0  | SKIP 1 | PASS 615
```
