### PR TITLE
fix(io): zero leftover NA cells in geno_to_treemix output

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -4169,8 +4169,10 @@ geno_to_treemix = function(pref, outfile = paste0(pref, '.txt.gz'), pops = NULL,
   }
   cnt = rowSums(afs$counts > 0)
   nomiss = cnt == ncol(afs$counts)
-  m1 = replace_na(afs$counts * afs$afs, 0)[nomiss,]
-  m2 = replace_na(afs$counts * (1-afs$afs), 0)[nomiss,]
+  # On a matrix, tidyr::replace_na() dispatches by row via vctrs and zeroes only rows
+  # that are entirely NA, so a partly NA row that passes `nomiss` keeps its NA. Zero elementwise.
+  m1 = afs$counts * afs$afs;     m1[is.na(m1)] = 0; m1 = m1[nomiss,]
+  m2 = afs$counts * (1-afs$afs); m2[is.na(m2)] = 0; m2 = m2[nomiss,]
 
   if(verbose) alert_info('Writing data in treemix format...\n')
   paste0(m1, ',', m2) %>% matrix(nrow(m1)) %>% as_tibble(.name_repair = ~colnames(m1)) %>%


### PR DESCRIPTION
## Summary

`geno_to_treemix()` calls `tidyr::replace_na()` to turn missing allele
frequency products into `0` before writing the treemix file. On a matrix
`replace_na()` does not do that. It replaces by row, so a row that still
holds a real value keeps its `NA`. This patch zeroes the missing cells with
base R instead, which is what the original line intended.

## The problem

```r
m1 = replace_na(afs$counts * afs$afs, 0)[nomiss,]
m2 = replace_na(afs$counts * (1-afs$afs), 0)[nomiss,]
```

`afs$counts * afs$afs` is a SNP by population matrix. Under tidyr 1.3.2 with
vctrs 0.7.3, `replace_na()` on a matrix dispatches through
`vctrs::vec_detect_missing`, which flags whole rows. Only rows that are
entirely `NA` get replaced, so a row with a value in one population and `NA`
in another keeps the `NA`.

The row filter is `nomiss = rowSums(afs$counts > 0) == ncol(afs$counts)`,
which keys on counts, not on `NA` in `afs`. So a SNP with `counts > 0` in
every population but `afs = NA` somewhere passes the filter, and its `NA`
reaches the file as the string `NA,NA`, which treemix cannot parse.

```r
library(tidyr)
m = rbind(c(5, NA), c(NA, 3))   # two partial NA rows, neither fully NA
replace_na(m, 0)
#      [,1] [,2]
# [1,]    5   NA      # this NA should have become 0
# [2,]   NA    3      # and so should this one
```

## The fix

```r
m1 = afs$counts * afs$afs;     m1[is.na(m1)] = 0; m1 = m1[nomiss,]
m2 = afs$counts * (1-afs$afs); m2[is.na(m2)] = 0; m2 = m2[nomiss,]
```

Base R indexing zeroes every `NA` cell, which is what `replace_na(_, 0)` was
asking for. On input with no `NA` the result is identical to the old line.

## Impact

This is latent in normal use today. Every genotype backend ties `afs = NA` to
`counts = 0`. The C++ reader writes `afs` and `counts` together only when
`observedalleles > 0` (`src/cpp_readgeno.cpp`), and the R readers compute
`afs = numerator / counts`. So a missing frequency always carries a zero
count, and `nomiss` already drops that row before the write step. The patch
is a correctness guard. It removes the silent failure for any path that
produces a missing frequency with a positive count, and it leaves current
output unchanged.

## Testing

- Reproduced the surviving `NA` on a synthetic afs and confirmed the patch zeroes it.
- Ran the real `geno_to_treemix()` end to end against an afs with a `counts > 0` and `afs = NA` cell. The current function writes `NA,NA`, the patched function writes `0,0`, and every other row is identical.
- Confirmed the patched and original code agree exactly on input with no `NA`.
- No signature or export changes, so no NAMESPACE update is needed.
