### PR TITLE
fix(resampling): correct NA handling in block-jackknife leave-one-out

### DIFF
--- a/R/qpadm.R
+++ b/R/qpadm.R
@@ -381,7 +381,16 @@ qpadm = function(data, left, right, target, f4blocks = NULL,
                            qpsolve = qpsolve)$weights %>% c
     if(getcov) {
       if(verbose) alert_info('Computing standard errors...\n')
-      se = sqrt(diag(get_weights_covariance(f4_lo, qinv, block_lengths, fudge = fudge, boot = boot,
+      # Compute weight SEs over the leave-one-out replicates with no missing
+      # values, the same surviving block set jack_pairarr_stats uses for f4_var.
+      # Neither weight-covariance backend (R or cpp) tolerates NA; on the common
+      # remove_na path f4_lo is already complete, so this is a no-op there.
+      finreps = apply(f4_lo, 3, function(x) sum(!is.finite(x)) == 0)
+      # A jackknife covariance needs at least 2 surviving blocks; cov() of a
+      # single leave-one-out replicate is NA (R backend) or 0/NaN (cpp), silently.
+      if(sum(finreps) < 2) stop("Fewer than 2 non-missing blocks; cannot compute weight standard errors.")
+      se = sqrt(diag(get_weights_covariance(f4_lo[,,finreps, drop = FALSE], qinv,
+                                            block_lengths[finreps], fudge = fudge, boot = boot,
                                             constrained = constrained, qpsolve = qpsolve)))
     } else se = NA
     out$weights = tibble(target, left = left[-1], weight, se) %>% mutate(z = weight/se)

--- a/R/qpadm.R
+++ b/R/qpadm.R
@@ -388,6 +388,9 @@ qpadm = function(data, left, right, target, f4blocks = NULL,
       finreps = apply(f4_lo, 3, function(x) sum(!is.finite(x)) == 0)
       # A jackknife covariance needs at least 2 surviving blocks; cov() of a
       # single leave-one-out replicate is NA (R backend) or 0/NaN (cpp), silently.
+      # This is intentionally stricter than jack_pairarr_stats (which only stops
+      # at 0 surviving blocks) because a single-block weight covariance is
+      # silently degenerate; the f4_var path's looser guard is left as-is.
       if(sum(finreps) < 2) stop("Fewer than 2 non-missing blocks; cannot compute weight standard errors.")
       se = sqrt(diag(get_weights_covariance(f4_lo[,,finreps, drop = FALSE], qinv,
                                             block_lengths[finreps], fudge = fudge, boot = boot,

--- a/R/resampling.R
+++ b/R/resampling.R
@@ -102,7 +102,13 @@ jack_mat_stats = function(loo_mat, block_lengths, tot = NULL, na.rm = TRUE) {
   h = rep(n/block_lengths, each = nrow(loo_mat))
   taumat = h*totmat - (h-1)*loo_mat
   xtau = (taumat - estmat) / sqrt(h-1)
-  var = tcrossprod(replace_na(xtau, 0))/tcrossprod(!is.na(xtau))
+  # Zero missing deviations element-wise. tidyr::replace_na() no-ops on a matrix
+  # (vctrs treats it as a vector of rows), so use base-R indexing. xtau holds
+  # centered pseudo-deviations, so 0 means "no contribution" and the
+  # tcrossprod(!is.na(xtau)) denominator counts the present pairs (a pairwise-
+  # complete covariance).
+  xtau0 = xtau; xtau0[is.na(xtau0)] = 0
+  var = tcrossprod(xtau0)/tcrossprod(!is.na(xtau))
 
   namedList(est, var)
 }
@@ -122,7 +128,9 @@ jack_mat_stats2 = function(loo_mat, block_lengths, na.rm = TRUE) {
   xtau = (est - loo_mat) * sqrt(h-1)
   #est = weighted_row_means(loo_mat, 1-1/h, na.rm=na.rm)
   #xtau = (est - loo_mat) * sqrt(rep(h, each = nrow(loo_mat))-1)
-  var = tcrossprod(replace_na(xtau, 0)) / tcrossprod(!is.na(xtau))
+  # Zero missing deviations element-wise; replace_na() no-ops on a matrix.
+  xtau0 = xtau; xtau0[is.na(xtau0)] = 0
+  var = tcrossprod(xtau0) / tcrossprod(!is.na(xtau))
 
   namedList(est, var)
 }
@@ -355,15 +363,18 @@ loo_to_est = function(arr, block_lengths = NULL) {
 est_to_loo_nafix = function(arr) {
   # turns block estimates into leave-one-block-out estimates
   # assumes blocks are along 3rd dimension
-
-  block_lengths = parse_number(dimnames(arr)[[3]])
-  tot = apply(arr, 1:2, weighted.mean, block_lengths, na.rm=T)
-  rel_bl = rep(block_lengths/sum(block_lengths), each = length(tot))
-  if(any(is.na(arr))) warning(paste0('Replacing ', sum(is.na(arr)), ' NAs with 0!'))
-  arr %<>% replace_na(0)
-  out = (replicate(dim(arr)[3], tot) - arr*rel_bl) / (1-rel_bl)
-  dimnames(out) = dimnames(arr)
-  out
+  #
+  # Missing block entries are EXCLUDED, not replaced with 0. A missing block
+  # carries no information for that statistic, so its leave-one-out slice is
+  # left NA and downstream jackknife code (jack_pairarr_stats, and the weight
+  # covariance via the surviving-slice filter in qpadm) drops it. Substituting 0
+  # would impute a real f4 value of zero, biasing the estimate toward 0 by the
+  # missing fraction and inflating the variance. est_to_loo already does the
+  # correct NA-aware (present-block) reweighting; on data with no missing blocks
+  # this is identical to a plain leave-one-out.
+  if(any(is.na(arr)))
+    warning(paste0(sum(is.na(arr)), ' missing block entries excluded from leave-one-out estimates.'))
+  est_to_loo(arr)
 }
 
 #' Turn per-block estimates into bootstrap estimates

--- a/R/resampling.R
+++ b/R/resampling.R
@@ -106,7 +106,8 @@ jack_mat_stats = function(loo_mat, block_lengths, tot = NULL, na.rm = TRUE) {
   # (vctrs treats it as a vector of rows), so use base-R indexing. xtau holds
   # centered pseudo-deviations, so 0 means "no contribution" and the
   # tcrossprod(!is.na(xtau)) denominator counts the present pairs (a pairwise-
-  # complete covariance).
+  # complete covariance). This assumes each pair of rows shares at least one
+  # present block; a pair with no overlap gives 0/0 = NaN, as before this fix.
   xtau0 = xtau; xtau0[is.na(xtau0)] = 0
   var = tcrossprod(xtau0)/tcrossprod(!is.na(xtau))
 
@@ -129,6 +130,8 @@ jack_mat_stats2 = function(loo_mat, block_lengths, na.rm = TRUE) {
   #est = weighted_row_means(loo_mat, 1-1/h, na.rm=na.rm)
   #xtau = (est - loo_mat) * sqrt(rep(h, each = nrow(loo_mat))-1)
   # Zero missing deviations element-wise; replace_na() no-ops on a matrix.
+  # Pairwise-complete covariance: a row pair with no shared present block gives
+  # 0/0 = NaN (unchanged by this fix).
   xtau0 = xtau; xtau0[is.na(xtau0)] = 0
   var = tcrossprod(xtau0) / tcrossprod(!is.na(xtau))
 

--- a/tests/testthat/test-resampling-na-handling.R
+++ b/tests/testthat/test-resampling-na-handling.R
@@ -1,0 +1,84 @@
+# Regression tests for NA handling in the block-jackknife leave-one-out path.
+#
+# tidyr::replace_na() dispatches row-wise via vctrs, so it no-ops on matrices /
+# 3D arrays that carry partial NAs. The fixes:
+#   - jack_mat_stats / jack_mat_stats2: base-R element-wise zeroing of the
+#     centered deviation matrix xtau (0 = "no contribution", correct for a
+#     pairwise-complete covariance).
+#   - est_to_loo_nafix: NA-aware exclusion of missing blocks (delegates to
+#     est_to_loo) instead of substituting 0 for a raw f4 block estimate.
+#   - qpadm: weight SEs are computed over the surviving (non-missing) leave-one-
+#     out blocks, the same set f4_var uses, instead of erroring / returning NaN.
+
+test_that("est_to_loo_nafix matches a plain leave-one-out on complete data", {
+  data('example_f2_blocks', package = 'admixtools')
+  blk <- example_f2_blocks[1:3, 1:3, 1:25]
+  expect_false(anyNA(blk))
+  expect_silent(out <- admixtools:::est_to_loo_nafix(blk))
+  expect_equal(out, admixtools:::est_to_loo(blk))
+  expect_false(anyNA(out))
+})
+
+test_that("est_to_loo_nafix excludes missing blocks instead of substituting 0", {
+  data('example_f2_blocks', package = 'admixtools')
+  blk <- example_f2_blocks[1:3, 1:3, 1:25]
+  blk[1, 2, 5] <- NA_real_
+  blk[2, 1, 5] <- NA_real_
+
+  # honest warning (the old text falsely claimed "Replacing N NAs with 0!")
+  expect_warning(out <- admixtools:::est_to_loo_nafix(blk),
+                 regexp = 'missing block entries excluded')
+
+  # NA-aware exclusion == est_to_loo, NOT 0-substitution
+  expect_equal(out, admixtools:::est_to_loo(blk))
+
+  # the leave-one-out slice that removes the missing block stays NA in that cell
+  # so downstream jackknife code drops it, rather than the 0-substituted value
+  expect_true(is.na(out[1, 2, 5]))
+
+  # 0-substitution would have produced a finite, nonzero (wrong) value there
+  bl  <- readr::parse_number(dimnames(blk)[[3]])
+  tot <- weighted.mean(blk[1, 2, ], bl, na.rm = TRUE)
+  wrong_0sub <- tot / (1 - bl[5] / sum(bl))
+  expect_true(is.finite(wrong_0sub) && wrong_0sub != 0)
+})
+
+test_that("jack_mat_stats2 returns a finite covariance on partial-NA input", {
+  set.seed(1)
+  loo <- matrix(rnorm(5 * 8, sd = 1e-3), nrow = 5)   # 5 popcombos x 8 blocks
+  bl  <- rep(100, 8)
+
+  v_full <- admixtools:::jack_mat_stats2(loo, bl)$var
+  expect_true(all(is.finite(v_full)))
+
+  # one block missing for popcomb 2 (some-but-not-all -> a partial-NA row).
+  # Pre-fix, replace_na() left the NA and tcrossprod spread it across row/col 2.
+  loo_na <- loo; loo_na[2, 3] <- NA_real_
+  v_na <- admixtools:::jack_mat_stats2(loo_na, bl)$var
+  expect_false(anyNA(v_na))
+  expect_true(all(is.finite(v_na)))
+
+  # covariance entries not touching the missing pairing are unchanged
+  expect_equal(v_na[1, 4], v_full[1, 4])
+})
+
+test_that("qpadm returns finite weight SEs when an f2 block is partly missing", {
+  data('example_f2_blocks', package = 'admixtools')
+  f2 <- example_f2_blocks
+  target <- "Denisova.DG"
+  left   <- c("Altai_Neanderthal.DG", "Vindija.DG")
+  right  <- c("Chimp.REF", "Mbuti.DG", "Russia_Ust_Ishim.DG", "Switzerland_Bichon.SG")
+
+  # knock out one population pair in one block (f2 is symmetric)
+  f2[target, right[1], 5] <- NA_real_
+  f2[right[1], target, 5] <- NA_real_
+
+  # Pre-fix this errored (R svd on an NA slice) or returned NaN SEs (cpp). Post-
+  # fix the weight covariance uses the surviving-block set, matching f4_var.
+  res <- suppressMessages(suppressWarnings(
+    qpadm(f2, left = left, right = right, target = target, verbose = FALSE)
+  ))
+  expect_true(all(is.finite(res$weights$se)))
+  expect_true(all(is.finite(res$weights$weight)))
+  expect_true(is.finite(res$f4_var_rcond))
+})


### PR DESCRIPTION
## What

`tidyr::replace_na(x, 0)` is a no-op on a matrix or 3D array. Under vctrs it
detects missingness by row/slice, so it zeroes only entries whose entire
row/slice is NA and silently leaves partial NAs in place (verified on tidyr
1.3.2 / vctrs 0.7.3, R 4.6.0). Three places in the jackknife path relied on it
to zero NA element-wise, so on inputs with missing blocks they leaked NA into
downstream math. This corrects all three and makes the qpadm/qpwave weight
standard errors well-defined when blocks are missing.

## Fixes

- **`jack_mat_stats` / `jack_mat_stats2`** (`R/resampling.R`): zero the centered
  pseudo-deviation matrix `xtau` element-wise with base-R indexing before
  `tcrossprod`. The deviations are centered, so 0 means "no contribution" and
  the `tcrossprod(!is.na(xtau))` denominator counts the present pairs (a
  pairwise-complete covariance). Previously a partial-NA row propagated NA
  across its whole row and column of the variance matrix.

- **`est_to_loo_nafix`** (`R/resampling.R`): missing blocks are now excluded,
  not replaced with 0. A missing block carries no information for that
  statistic, so 0-substitution would impute a real f4 value of zero, biasing the
  estimate toward 0 by the missing fraction and inflating the variance. It now
  delegates to `est_to_loo`, which does the correct present-block reweighting and
  leaves the missing leave-one-out cells NA for the downstream jackknife to drop.
  The warning is now accurate (it previously claimed "Replacing N NAs with 0!",
  which never happened).

- **`qpadm` weight standard errors** (`R/qpadm.R`): the weight covariance is now
  computed over the leave-one-out replicates with no missing values, the same
  surviving block set `jack_pairarr_stats` uses for `f4_var`. Neither covariance
  backend (R or cpp) tolerates NA, so previously a missing block made the R path
  error in `svd` and the cpp path return NaN SEs. A guard stops with a clear
  message when fewer than two blocks survive, since a jackknife covariance is
  undefined otherwise.

## Impact

- On the common `remove_na = TRUE` geno path, `f4_lo` is already complete, so
  this is a no-op and results are byte-identical.
- On sparse inputs (f2-blocks arrays, a supplied `f4blocks`, or
  `remove_na = FALSE`) with missing blocks, qpadm/qpwave weight SEs change from
  an error or NaN to a finite jackknife over the surviving blocks (matching how
  `f4_var` is already computed), and f4 jackknife variances no longer absorb
  leaked NA.

## Testing

- New `tests/testthat/test-resampling-na-handling.R`: `est_to_loo_nafix` matches
  a plain leave-one-out on complete data and excludes (does not 0-substitute)
  missing blocks with an accurate warning; `jack_mat_stats2` returns a finite
  covariance on partial-NA input; `qpadm` returns finite weight SEs when an f2
  block is partly missing.
- `test_dir(filter = "qpadm|qpwave|qpfstats|resampling|jack")`: 242 pass, 0 fail.
  Existing complete-data tests are unchanged, confirming no behavior change off
  the missing-data path.
