### PR TITLE
fix(fstats): correct NA handling in allele-product f-stats (maxmiss > 0)

### DIFF
--- a/R/fstats.R
+++ b/R/fstats.R
@@ -348,8 +348,15 @@ xmats_to_pairarrs = function(xmat1, xmat2) {
   ploidy2 = attr(xmat2, 'ploidy')
   n1 = (!is.na(xmat1)) * rep(ploidy1, each = nr)
   n2 = (!is.na(xmat2)) * rep(ploidy2, each = nr)
-  xmat1 %<>% replace_na(0)
-  xmat2 %<>% replace_na(0)
+  # Zero missing allele values element-wise so a missing genotype contributes 0
+  # to the allele product aa, matching n1/n2 contributing 0 to the count product
+  # nn. replace_na() is a no-op on a matrix whose NA cells do not fill an entire
+  # row (vctrs detects missingness by row); a leaked NA then drops out of aa's
+  # block mean (na.rm) but not nn's, silently biasing f-stats for pairs with
+  # missing data. No effect at the default maxmiss = 0, where SNPs with any
+  # missing population are dropped upstream so xmat has no NA here.
+  xmat1[is.na(xmat1)] = 0
+  xmat2[is.na(xmat2)] = 0
   aa = prodarray(xmat1, xmat2)
   nn = prodarray(n1, n2)
   dimnames(aa)[1:2] = dimnames(nn)[1:2] = list(colnames(xmat1), colnames(xmat2))

--- a/tests/testthat/test-fstats-na-handling.R
+++ b/tests/testthat/test-fstats-na-handling.R
@@ -1,0 +1,42 @@
+test_that("xmats_to_pairarrs zeroes missing genotypes element-wise (replace_na no-ops on a matrix)", {
+
+  # SNP x population dosage matrix. fix_ploidy reads every column as diploid
+  # because each contains 0, 1 and 2, so no pseudohaploid rescaling occurs.
+  base <- matrix(c(0, 1, 2,
+                   2, 0, 1,
+                   1, 2, 0,
+                   2, 1, 0), nrow = 4, byrow = TRUE,
+                 dimnames = list(NULL, c("A", "B", "C")))
+
+  # Two extra SNPs missing in B only (NA in column B, present in A and C).
+  # These are exactly the partial-NA rows that survive an extract with
+  # maxmiss > 0 and that replace_na() fails to zero on a matrix.
+  add <- matrix(c(1, NA, 2,
+                  0, NA, 1), nrow = 2, byrow = TRUE,
+                dimnames = list(NULL, c("A", "B", "C")))
+  ext <- rbind(base, add)
+
+  ratio_pair <- function(m, p, q) {
+    arrs <- admixtools:::xmats_to_pairarrs(m, m)
+    bl <- nrow(m)
+    (admixtools:::block_arr_mean(arrs$aa, bl) /
+       admixtools:::block_arr_mean(arrs$nn, bl))[p, q, 1]
+  }
+
+  # 1) Regression: no NA leaks into the allele-product / count arrays.
+  arrs_ext <- admixtools:::xmats_to_pairarrs(ext, ext)
+  expect_true(all(is.finite(arrs_ext$aa)))
+  expect_true(all(is.finite(arrs_ext$nn)))
+
+  # 2) Correctness: a SNP missing in B contributes 0 to both aa and nn for
+  #    B-pairs, so adding such SNPs must not change the B-pair allele-product
+  #    ratio. Under the bug the dropped-from-aa-but-not-nn mismatch inflated it.
+  expect_equal(ratio_pair(ext, "A", "B"), ratio_pair(base, "A", "B"))
+  expect_equal(ratio_pair(ext, "B", "C"), ratio_pair(base, "B", "C"))
+
+  # Sanity: the added SNPs are present for the A-C pair, so that ratio DOES
+  # change. This confirms the invariance above is specific to the missing pop
+  # and the test is exercising real arithmetic.
+  expect_false(isTRUE(all.equal(ratio_pair(ext, "A", "C"),
+                                ratio_pair(base, "A", "C"))))
+})


### PR DESCRIPTION
## What

`tidyr::replace_na(x, 0)` is a no-op on a matrix whose NA cells do not fill an
entire row. Under vctrs it detects missingness by row, so it zeroes only fully-NA
rows and silently leaves partial NAs in place (verified on tidyr 1.3.2 / vctrs
0.7.3, R 4.6.0). `xmats_to_pairarrs` relied on it to zero missing genotypes
element-wise before forming the per-SNP allele-product array `aa`, so with
missing genotypes present the leaked NA propagated into `aa`.

Because the per-block reducer `block_arr_mean` uses `na.rm = TRUE`, this did not
surface as a NaN. Instead the missing SNP dropped out of `aa`'s block mean (its
count) while `nn`'s block mean still counted it (a finite 0), so the two means
were taken over different SNP counts and the allele-product ratio `aa / nn` was
inflated by roughly `N / (N - k)` for a pair with `k` missing SNPs in a block of
`N`. The result was a silent upward bias in f2/f3/f4 statistics, with no warning.

## Fix

Zero the missing cells element-wise with base-R indexing
(`xmat1[is.na(xmat1)] <- 0`), which `prodarray` turns into a 0 contribution
matched by `n1`/`n2` contributing 0 to the count product. The ratio becomes
`sum(aa) / sum(nn)` over the present SNPs, the intended pairwise-complete
estimate.

## Impact

- No effect at the default `maxmiss = 0`: SNPs with any missing population are
  dropped upstream by `discard_snps`, so `xmat` has no NA at this point and the
  fix is a no-op (results byte-identical).
- With `maxmiss > 0` (used to retain SNPs in high-missingness data), f2/f3/f4
  statistics for population pairs that have missing data change from the silently
  biased value to the correct pairwise-complete estimate.
- f2 caches computed with `maxmiss > 0` under the old code should be re-extracted
  to pick up the fix: the cache id is keyed on inputs and parameters, not package
  version, so a same-argument re-run would otherwise reuse the biased values.

## Testing

- New `tests/testthat/test-fstats-na-handling.R`: `xmats_to_pairarrs` leaves no
  non-finite value in `aa`/`nn` on partial-NA input, and adding SNPs missing for
  a population does not change that population's pair ratios (the invariant the
  bug broke), while a fully-present pair's ratio does change.
- `test_dir(filter = "qpadm|qpwave|qpfstats|resampling|jack|fstat|f2|f3|f4|extract|count")`:
  309 pass, 0 fail. Complete-data tests are unchanged, confirming no behavior
  change off the missing-data path.

## Related

Last of the three sites where `replace_na` was applied to a matrix/array. See
#153 (io.R `geno_to_treemix`) and #154 (resampling block-jackknife).
