### PR TITLE
Add fix_times mode to graph_to_lgo and a clearer time-consistency error

### DIFF
--- a/R/legofit.R
+++ b/R/legofit.R
@@ -1263,8 +1263,8 @@ validate_via_roundtrip <- function(lgo_text, edges) {
 #'   `time free`. Use this with a free `twoN` (a named `twoN=` vector) when you
 #'   need to recover **absolute** effective population sizes: with both times and
 #'   `twoN` free, site-pattern data fit only the `Δt/twoN` ratios, so the absolute
-#'   scale is unidentified (the same degeneracy `read_legofit_output()` flags as
-#'   `scale_degenerate`). Fixing the times removes that degeneracy. With
+#'   scale is unidentified (the data constrain the ratios but not the overall
+#'   scale). Fixing the times removes that degeneracy. With
 #'   `"fix_admix"` or `"init"` the fixed values are the real absolute times, so
 #'   the recovered `twoN` is absolute. With `"free"` (the only mode that exports
 #'   additively-inconsistent graphs, e.g. most admixture topologies) the fixed

--- a/R/legofit.R
+++ b/R/legofit.R
@@ -464,7 +464,8 @@ topology_walk_bottom_up <- function(edges, branch_lengths, leaf_times,
             c(sprintf("Inconsistent branch lengths at node `%s`.", u),
               "x" = sprintf("Computed t=%g via one path and t=%g via edge %s->%s.",
                             node_time[u], proposed, u, v),
-              "i" = "Input drifts imply inconsistent absolute times."),
+              "i" = "Input drifts imply inconsistent absolute times. This is common: random and real qpgraph drifts are rarely additively consistent across paths.",
+              "i" = "Use `time_handling = \"free\"` (depth-seeded free times; the LEGOFIT optimizer fits them, but the input absolute times are not preserved), or `time_handling = \"init\"` with an explicit `time` column to supply consistent times yourself."),
             class = "legofit_invalid_input"
           )
         }
@@ -539,7 +540,7 @@ compute_node_depths <- function(edges) {
 
 #' @keywords internal
 compute_times <- function(edges, time_handling, drift_to_time,
-                          dates_terminal) {
+                          dates_terminal, fix_times = FALSE) {
   required_cols <- c("from", "to", "type", "weight")
   if (!is.data.frame(edges) || !all(required_cols %in% names(edges))) {
     rlang::abort(
@@ -582,9 +583,11 @@ compute_times <- function(edges, time_handling, drift_to_time,
     non_leaf <- setdiff(all_nodes, leaves)
     depths   <- compute_node_depths(edges)
     init_t   <- setNames(as.numeric(depths[non_leaf]), non_leaf)
+    free_vec <- setNames(!(all_nodes %in% leaves), all_nodes)
+    if (isTRUE(fix_times)) free_vec[] <- FALSE   # fix_times: pin internal times
     return(list(
       value = c(terminal_t, init_t)[all_nodes],
-      free  = setNames(!(all_nodes %in% leaves), all_nodes),
+      free  = free_vec,
       omit  = character(0)
     ))
   }
@@ -607,10 +610,11 @@ compute_times <- function(edges, time_handling, drift_to_time,
   # like any other node — they aren't omitted from time declarations.
   # The LEGOFIT param-sharing constraint is handled by the ghost
   # segments anchoring at T_admix_<dest> instead.
-  free <- switch(time_handling,
-    "fix_admix" = setNames(!(all_nodes %in% leaves), all_nodes),
-    "init"      = setNames(!(all_nodes %in% leaves), all_nodes)
-  )
+  free <- setNames(!(all_nodes %in% leaves), all_nodes)
+  # fix_times: emit internal node times as `time fixed` at their computed
+  # absolute values, so a model with free `twoN` is no longer degenerate up to a
+  # global scale and absolute twoN becomes recoverable.
+  if (isTRUE(fix_times)) free[] <- FALSE
 
   list(value = node_time[all_nodes], free = free, omit = character(0))
 }
@@ -632,7 +636,8 @@ admix_parent_pairs <- function(edges) {
 
 format_time_declarations <- function(time_param_names, times,
                                      admix_time_param_names = NULL,
-                                     admix_pairs = NULL) {
+                                     admix_pairs = NULL,
+                                     fix_times = FALSE) {
   # Per-node time declarations (every node gets one — admix dests are no
   # longer omitted; ghost segments handle the param-sharing constraint).
   keep <- names(time_param_names)
@@ -649,11 +654,16 @@ format_time_declarations <- function(time_param_names, times,
   # which are unique per node.
   node_lines <- node_lines[!duplicated(time_param_names[ordered])]
 
-  # Per-admix-event time declarations (T_admix_<M>). Always free — the
-  # admix event time is what LEGOFIT optimizes.
+  # Per-admix-event time declarations (T_admix_<M>). Free by default (the admix
+  # event time is what LEGOFIT optimizes), but fixed under `fix_times`: leaving it
+  # free while twoN is free reintroduces the scale degeneracy and wrecks absolute
+  # twoN recovery. The admix-event time is structurally non-identifiable either
+  # way (its segment carries a single lineage, so no coalescence), so pinning it
+  # is safe.
   admix_lines <- character(0)
   if (!is.null(admix_pairs) && nrow(admix_pairs) > 0) {
-    admix_lines <- sprintf("time free %s=%g",
+    admix_lines <- sprintf("time %s %s=%g",
+                           if (isTRUE(fix_times)) "fixed" else "free",
                            admix_time_param_names[admix_pairs$to],
                            times$value[admix_pairs$high])
   }
@@ -750,7 +760,8 @@ format_mix_statements <- function(edges_admix, mixfrac_param_names) {
 }
 
 #' @keywords internal
-assemble_lgo <- function(edges, params, times, twoN_decls, samples_vec) {
+assemble_lgo <- function(edges, params, times, twoN_decls, samples_vec,
+                         fix_times = FALSE) {
   all_nodes   <- unique(c(edges$from, edges$to))
   admix_pairs <- admix_parent_pairs(edges)
 
@@ -774,7 +785,8 @@ assemble_lgo <- function(edges, params, times, twoN_decls, samples_vec) {
   }
 
   time_decls   <- format_time_declarations(params$time, times,
-                                           params$admix_time, admix_pairs)
+                                           params$admix_time, admix_pairs,
+                                           fix_times = fix_times)
   mfrac_decls  <- format_mixfrac_declarations(params$mixFrac, edges)
   seg_decls    <- format_segment_declarations(all_nodes, params$time,
                                               twoN_decls$per_segment,
@@ -1246,9 +1258,32 @@ validate_via_roundtrip <- function(lgo_text, edges) {
 #' @param drift_to_time Function converting per-edge drift to branch length.
 #'   Default [default_drift_to_time()] (identity). Ignored when
 #'   `time_handling = "free"` or when an explicit `time` column is present.
+#' @param fix_times Logical (default `FALSE`). When `TRUE`, internal-node times
+#'   are emitted as `time fixed` at their computed absolute values rather than
+#'   `time free`. Use this with a free `twoN` (a named `twoN=` vector) when you
+#'   need to recover **absolute** effective population sizes: with both times and
+#'   `twoN` free, site-pattern data fit only the `Δt/twoN` ratios, so the absolute
+#'   scale is unidentified (the same degeneracy `read_legofit_output()` flags as
+#'   `scale_degenerate`). Fixing the times removes that degeneracy. With
+#'   `"fix_admix"` or `"init"` the fixed values are the real absolute times, so
+#'   the recovered `twoN` is absolute. With `"free"` (the only mode that exports
+#'   additively-inconsistent graphs, e.g. most admixture topologies) the fixed
+#'   values are topological-depth placeholders: still consistent and still enough
+#'   to make `twoN` identifiable in a self-consistent fit, but not biologically
+#'   calibrated absolute times.
 #' @param validate If `TRUE` (default), round-trips the output through
 #'   [read_lgo()] to confirm topology is preserved.
 #' @return The `.lgo` text, invisibly.
+#' @examples
+#' # A 3-leaf no-admixture graph with explicit node times.
+#' g <- tibble::tribble(
+#'   ~from,  ~to,  ~type,    ~weight,  ~time,
+#'   "xyz",  "xy", "normal", NA_real_, 1.5,
+#'   "xyz",  "z",  "normal", NA_real_, 2,
+#'   "xy",   "x",  "normal", NA_real_, 0.5,
+#'   "xy",   "y",  "normal", NA_real_, 0.5
+#' )
+#' cat(graph_to_lgo(g, time_handling = "init"))
 #' @export
 graph_to_lgo <- function(graph,
                          file = NULL,
@@ -1258,6 +1293,7 @@ graph_to_lgo <- function(graph,
                          twoN = NULL,
                          time_handling = c("fix_admix", "init", "free"),
                          drift_to_time = default_drift_to_time,
+                         fix_times = FALSE,
                          validate = TRUE) {
 
   time_handling <- match.arg(time_handling)
@@ -1269,7 +1305,8 @@ graph_to_lgo <- function(graph,
   if (!is.null(outpop)) edges <- strip_outgroup(edges, outpop)
 
   params <- generate_param_names(edges)
-  times  <- compute_times(edges, time_handling, drift_to_time, dates_terminal)
+  times  <- compute_times(edges, time_handling, drift_to_time, dates_terminal,
+                          fix_times = fix_times)
   twoN_decls <- resolve_twoN_decls(edges, twoN)
 
   leaves       <- setdiff(edges$to, edges$from)
@@ -1364,7 +1401,8 @@ graph_to_lgo <- function(graph,
     }
   }
 
-  lgo_text <- assemble_lgo(edges, params, times, twoN_decls, full_samples)
+  lgo_text <- assemble_lgo(edges, params, times, twoN_decls, full_samples,
+                           fix_times = fix_times)
 
   is_sampled <- !is.na(full_samples) & full_samples > 0
   n_sampled <- sum(is_sampled)

--- a/man/graph_to_lgo.Rd
+++ b/man/graph_to_lgo.Rd
@@ -62,8 +62,8 @@ are emitted as \verb{time fixed} at their computed absolute values rather than
 \verb{time free}. Use this with a free \code{twoN} (a named \verb{twoN=} vector) when you
 need to recover \strong{absolute} effective population sizes: with both times and
 \code{twoN} free, site-pattern data fit only the \code{Δt/twoN} ratios, so the absolute
-scale is unidentified (the same degeneracy \code{read_legofit_output()} flags as
-\code{scale_degenerate}). Fixing the times removes that degeneracy. With
+scale is unidentified (the data constrain the ratios but not the overall
+scale). Fixing the times removes that degeneracy. With
 \code{"fix_admix"} or \code{"init"} the fixed values are the real absolute times, so
 the recovered \code{twoN} is absolute. With \code{"free"} (the only mode that exports
 additively-inconsistent graphs, e.g. most admixture topologies) the fixed

--- a/man/graph_to_lgo.Rd
+++ b/man/graph_to_lgo.Rd
@@ -13,6 +13,7 @@ graph_to_lgo(
   twoN = NULL,
   time_handling = c("fix_admix", "init", "free"),
   drift_to_time = default_drift_to_time,
+  fix_times = FALSE,
   validate = TRUE
 )
 }
@@ -56,6 +57,20 @@ rather than time-walk consistency).
 Default \code{\link[=default_drift_to_time]{default_drift_to_time()}} (identity). Ignored when
 \code{time_handling = "free"} or when an explicit \code{time} column is present.}
 
+\item{fix_times}{Logical (default \code{FALSE}). When \code{TRUE}, internal-node times
+are emitted as \verb{time fixed} at their computed absolute values rather than
+\verb{time free}. Use this with a free \code{twoN} (a named \verb{twoN=} vector) when you
+need to recover \strong{absolute} effective population sizes: with both times and
+\code{twoN} free, site-pattern data fit only the \code{Δt/twoN} ratios, so the absolute
+scale is unidentified (the same degeneracy \code{read_legofit_output()} flags as
+\code{scale_degenerate}). Fixing the times removes that degeneracy. With
+\code{"fix_admix"} or \code{"init"} the fixed values are the real absolute times, so
+the recovered \code{twoN} is absolute. With \code{"free"} (the only mode that exports
+additively-inconsistent graphs, e.g. most admixture topologies) the fixed
+values are topological-depth placeholders: still consistent and still enough
+to make \code{twoN} identifiable in a self-consistent fit, but not biologically
+calibrated absolute times.}
+
 \item{validate}{If \code{TRUE} (default), round-trips the output through
 \code{\link[=read_lgo]{read_lgo()}} to confirm topology is preserved.}
 }
@@ -65,4 +80,15 @@ The \code{.lgo} text, invisibly.
 \description{
 Converts an admixtools admixture graph (as an edge tibble or igraph) into
 a LEGOFIT-compatible \code{.lgo} file.
+}
+\examples{
+# A 3-leaf no-admixture graph with explicit node times.
+g <- tibble::tribble(
+  ~from,  ~to,  ~type,    ~weight,  ~time,
+  "xyz",  "xy", "normal", NA_real_, 1.5,
+  "xyz",  "z",  "normal", NA_real_, 2,
+  "xy",   "x",  "normal", NA_real_, 0.5,
+  "xy",   "y",  "normal", NA_real_, 0.5
+)
+cat(graph_to_lgo(g, time_handling = "init"))
 }

--- a/tests/testthat/test-functional.R
+++ b/tests/testthat/test-functional.R
@@ -297,13 +297,16 @@ test_that("PF-4: graph_to_lgo on a 100-node graph stays bounded (format_* at sca
   skip_on_cran()
   # The documented performance bound is only on read_lgo; the format_* writer
   # helpers were never profiled at scale. Time the writer on the same large graph.
+  # The threshold is a generous ceiling to catch pathological (e.g. quadratic)
+  # scaling, not a tight latency assertion, so it tolerates a slow or loaded CI.
+  # outpref = tempfile() keeps random_sim's generated .py out of the test tree.
   set.seed(123)
-  big <- random_sim(nadmix = 3, nleaf = 50)
+  big <- random_sim(nadmix = 3, nleaf = 50, outpref = tempfile())
   expect_gte(length(unique(c(big$edges$from, big$edges$to))), 50)
   t <- system.time(
     graph_to_lgo(big$edges, time_handling = "free", validate = FALSE)
   )[["elapsed"]]
-  expect_lt(t, 1.0)
+  expect_lt(t, 3.0)
 })
 
 # T1.8 ------------------------------------------------------------------

--- a/tests/testthat/test-functional.R
+++ b/tests/testthat/test-functional.R
@@ -1,5 +1,4 @@
-# Tier 1 functional tests. See:
-# /Volumes/Bioinformation/Claude/cs-wiki/projects/at2-legofit-integration-pr-gamma-test-plan.md
+# Tier 1 functional tests for the graph_to_lgo writer.
 #
 # Unlike test-graph_to_lgo.R (which exercises individual helpers on the
 # minimal 5-node fixture), this file runs the integrated pipeline on
@@ -291,6 +290,20 @@ test_that("T1.7: read_lgo handles a 100-node graph in under 500ms", {
   txt <- graph_to_lgo(big$edges, time_handling = "free", validate = FALSE)
   t <- system.time(read_lgo(text = txt))[["elapsed"]]
   expect_lt(t, 0.5)
+})
+
+# PF-4 ------------------------------------------------------------------
+test_that("PF-4: graph_to_lgo on a 100-node graph stays bounded (format_* at scale)", {
+  skip_on_cran()
+  # The documented performance bound is only on read_lgo; the format_* writer
+  # helpers were never profiled at scale. Time the writer on the same large graph.
+  set.seed(123)
+  big <- random_sim(nadmix = 3, nleaf = 50)
+  expect_gte(length(unique(c(big$edges$from, big$edges$to))), 50)
+  t <- system.time(
+    graph_to_lgo(big$edges, time_handling = "free", validate = FALSE)
+  )[["elapsed"]]
+  expect_lt(t, 1.0)
 })
 
 # T1.8 ------------------------------------------------------------------

--- a/tests/testthat/test-graph_to_lgo.R
+++ b/tests/testthat/test-graph_to_lgo.R
@@ -84,6 +84,42 @@ test_that("compute_times init: errors when default drift_to_time gives inconsist
   )
 })
 
+test_that("F-2: additive-inconsistency abort points to free/init alternatives", {
+  g <- make_minimal_graph()
+  expect_error(
+    compute_times(g, "init", default_drift_to_time, 0),
+    regexp = "free|init", class = "legofit_invalid_input"
+  )
+})
+
+test_that("F-4: fix_times emits `time fixed` for internal nodes (recovers absolute twoN)", {
+  expect_warning(
+    txt <- graph_to_lgo(make_minimal_graph(), time_handling = "free",
+                        fix_times = TRUE, validate = FALSE),
+    class = "legofit_unfittable_lgo")
+  expect_match(txt, "time fixed T_R")      # internal tree-node time is fixed
+  expect_false(grepl("time free", txt))    # no free time remains
+  expect_type(read_lgo(text = txt), "list")  # still parses
+})
+
+test_that("F-4: fix_times works with free mode on an admix graph", {
+  # free is the only mode that exports additively-inconsistent admix graphs;
+  # fix_times must still pin every time (including the admix-event time) so the
+  # absolute scale is identifiable rather than degenerate against free twoN.
+  txt <- graph_to_lgo(make_rogers2020_graph(), time_handling = "free",
+                      fix_times = TRUE, validate = FALSE)
+  expect_match(txt, "time fixed")
+  expect_false(grepl("time free", txt))
+})
+
+test_that("F-4: fix_times defaults FALSE (internal times stay free)", {
+  expect_warning(
+    txt <- graph_to_lgo(make_minimal_graph(), time_handling = "free",
+                        validate = FALSE),
+    class = "legofit_unfittable_lgo")
+  expect_match(txt, "time free T_R")
+})
+
 test_that("compute_times errors when graph has no leaves", {
   # Cycle: every node appears as both `from` and `to`
   cyclic <- tibble::tribble(
@@ -210,4 +246,20 @@ test_that("generate_param_names matches the parameter naming convention", {
   expect_equal(p$twoN["A"],    c(A = "twoN_A"))
   expect_equal(p$mixFrac["M"], c(M = "m_M"))
   expect_setequal(names(p$mixFrac), "M")  # only admix destinations
+})
+
+# ---------------------------------------------------------------------------
+# Master plan Tier 0 gap closure
+# ---------------------------------------------------------------------------
+
+# U-W12: graph_to_lgo(file=) writes exactly the text it returns when file=NULL.
+# The minimal graph emits the unfittable warning (one leaf); that is orthogonal
+# to the write contract, so it is suppressed here.
+test_that("U-W12: graph_to_lgo(file=) writes content equal to the file=NULL text return", {
+  g   <- make_minimal_graph()
+  txt <- suppressWarnings(graph_to_lgo(g))
+  tmp <- tempfile(fileext = ".lgo")
+  on.exit(unlink(tmp))
+  suppressWarnings(graph_to_lgo(g, file = tmp))
+  expect_identical(readLines(tmp), strsplit(txt, "\n", fixed = TRUE)[[1]])
 })

--- a/tests/testthat/test-graph_to_lgo.R
+++ b/tests/testthat/test-graph_to_lgo.R
@@ -249,7 +249,7 @@ test_that("generate_param_names matches the parameter naming convention", {
 })
 
 # ---------------------------------------------------------------------------
-# Master plan Tier 0 gap closure
+# Additional coverage for the write contract and fix_times
 # ---------------------------------------------------------------------------
 
 # U-W12: graph_to_lgo(file=) writes exactly the text it returns when file=NULL.


### PR DESCRIPTION
## Summary

Two follow-ups to `graph_to_lgo`, the admixtools to LEGOFIT `.lgo` writer added in #126.

**1. `fix_times` argument.** `graph_to_lgo(graph, fix_times = TRUE)` emits internal-node times as `time fixed` at their computed absolute values instead of `time free`. When a model pairs free per-segment `twoN` with free times, only the ratio `Delta_t/twoN` is identifiable, so absolute times and `twoN` are degenerate up to a global scale. Fixing the internal times removes that degeneracy and makes the absolute `twoN` values recoverable. Defaults to `FALSE`, so existing behavior is unchanged.

**2. Clearer additive-inconsistency error.** When `time_handling = "fix_admix"` (default) or `"init"` meets drift values that are not additively consistent across paths, the error now explains that this is common (qpgraph fits and random topologies rarely satisfy additive consistency) and points to `time_handling = "free"` or `"init"` with an explicit `time` column. Message only; no behavior change.

## Changes

- `R/legofit.R`: `fix_times` threaded through `compute_times`, `format_time_declarations`, `assemble_lgo`, `graph_to_lgo`; clearer abort in the topology walk.
- `man/graph_to_lgo.Rd`: regenerated.
- Tests: the error points to alternatives; `fix_times` emits `time fixed`, interacts correctly with `free` mode, and defaults off; a `graph_to_lgo` performance bound; a `file=` write-equivalence check.

## Testing

`R CMD check`: no ERROR (the 2 WARNINGs / 3 NOTEs are pre-existing: package vignettes and an archived-package Rd cross-reference). `testthat` green.
