### PR TITLE
perf: return integer genotype matrices from all genotype readers

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -373,7 +373,7 @@ discard_snps = function(snpdat, maxmiss = 1, keepsnps = NULL, auto_only = TRUE, 
 #' @param last Index of last SNP to read
 #' @param transpose Transpose genotype matrix (default is `snps` x `individuals`)
 #' @param verbose Print progress updates
-#' @return A list with the genotype data matrix, the `.ind` file, and the `.snp` file
+#' @return A list with the genotype data matrix (integer storage mode), the `.ind` file, and the `.snp` file
 #' @examples
 #' \dontrun{
 #' samples = c('Ind1', 'Ind2', 'Ind3')
@@ -449,7 +449,7 @@ read_packedancestrymap = function(pref, inds = NULL, pops = NULL, first = 1, las
 #'
 #' @export
 #' @inheritParams read_packedancestrymap
-#' @return A list with the genotype data matrix, the `.ind` file, and the `.snp` file
+#' @return A list with the genotype data matrix (integer storage mode), the `.ind` file, and the `.snp` file
 #' @examples
 #' \dontrun{
 #' samples = c('Ind1', 'Ind2', 'Ind3')
@@ -1389,7 +1389,7 @@ compute_f2_cache_id = function(pref, format = NULL, inds = NULL, pops = NULL,
 #' @param inds Individuals for which data should be read. Defaults to all individuals
 #' @param pops Populations for which data should be read. Cannot be provided together with 'inds'
 #' @inheritParams packedancestrymap_to_afs
-#' @return A list with the genotype data matrix, the `.ind` file, and the `.snp` file
+#' @return A list with the genotype data matrix (integer storage mode), the `.ind` file, and the `.snp` file
 #' @examples
 #' \dontrun{
 #' samples = c('Ind1', 'Ind2', 'Ind3')

--- a/man/read_eigenstrat.Rd
+++ b/man/read_eigenstrat.Rd
@@ -30,7 +30,7 @@ read_eigenstrat(
 \item{verbose}{Print progress updates}
 }
 \value{
-A list with the genotype data matrix, the \code{.ind} file, and the \code{.snp} file
+A list with the genotype data matrix (integer storage mode), the \code{.ind} file, and the \code{.snp} file
 }
 \description{
 Read genotype data from \emph{EIGENSTRAT} files

--- a/man/read_packedancestrymap.Rd
+++ b/man/read_packedancestrymap.Rd
@@ -30,7 +30,7 @@ read_packedancestrymap(
 \item{verbose}{Print progress updates}
 }
 \value{
-A list with the genotype data matrix, the \code{.ind} file, and the \code{.snp} file
+A list with the genotype data matrix (integer storage mode), the \code{.ind} file, and the \code{.snp} file
 }
 \description{
 Read genotype data from packedancestrymap files

--- a/man/read_plink.Rd
+++ b/man/read_plink.Rd
@@ -16,7 +16,7 @@ read_plink(pref, inds = NULL, pops = NULL, verbose = FALSE)
 \item{verbose}{Print progress updates}
 }
 \value{
-A list with the genotype data matrix, the \code{.ind} file, and the \code{.snp} file
+A list with the genotype data matrix (integer storage mode), the \code{.ind} file, and the \code{.snp} file
 }
 \description{
 See \href{https://www.rdocumentation.org/packages/genio}{genio} for a dedicated \code{R} package for

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -147,12 +147,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_gmat_to_aftable
-arma::mat cpp_gmat_to_aftable(arma::mat& gmat, arma::ivec& popvec, int nthreads);
+arma::mat cpp_gmat_to_aftable(arma::imat& gmat, arma::ivec& popvec, int nthreads);
 RcppExport SEXP _admixtools_cpp_gmat_to_aftable(SEXP gmatSEXP, SEXP popvecSEXP, SEXP nthreadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::mat& >::type gmat(gmatSEXP);
+    Rcpp::traits::input_parameter< arma::imat& >::type gmat(gmatSEXP);
     Rcpp::traits::input_parameter< arma::ivec& >::type popvec(popvecSEXP);
     Rcpp::traits::input_parameter< int >::type nthreads(nthreadsSEXP);
     rcpp_result_gen = Rcpp::wrap(cpp_gmat_to_aftable(gmat, popvec, nthreads));
@@ -291,7 +291,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_read_packedancestrymap
-NumericMatrix cpp_read_packedancestrymap(String genofile, int nsnp, int nind, IntegerVector indvec, int first, int last, bool transpose, bool verbose);
+IntegerMatrix cpp_read_packedancestrymap(String genofile, int nsnp, int nind, IntegerVector indvec, int first, int last, bool transpose, bool verbose);
 RcppExport SEXP _admixtools_cpp_read_packedancestrymap(SEXP genofileSEXP, SEXP nsnpSEXP, SEXP nindSEXP, SEXP indvecSEXP, SEXP firstSEXP, SEXP lastSEXP, SEXP transposeSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -343,7 +343,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_read_eigenstrat
-NumericMatrix cpp_read_eigenstrat(String genofile, int nsnp, int nind, IntegerVector indvec, int first, int last, bool transpose, bool verbose);
+IntegerMatrix cpp_read_eigenstrat(String genofile, int nsnp, int nind, IntegerVector indvec, int first, int last, bool transpose, bool verbose);
 RcppExport SEXP _admixtools_cpp_read_eigenstrat(SEXP genofileSEXP, SEXP nsnpSEXP, SEXP nindSEXP, SEXP indvecSEXP, SEXP firstSEXP, SEXP lastSEXP, SEXP transposeSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -361,7 +361,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_read_plink
-NumericMatrix cpp_read_plink(String bedfile, int nsnp, int nind, IntegerVector indvec, int first, int last, bool transpose, bool verbose);
+IntegerMatrix cpp_read_plink(String bedfile, int nsnp, int nind, IntegerVector indvec, int first, int last, bool transpose, bool verbose);
 RcppExport SEXP _admixtools_cpp_read_plink(SEXP bedfileSEXP, SEXP nsnpSEXP, SEXP nindSEXP, SEXP indvecSEXP, SEXP firstSEXP, SEXP lastSEXP, SEXP transposeSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/cpp_fstats.cpp
+++ b/src/cpp_fstats.cpp
@@ -522,12 +522,12 @@ NumericVector row_prods(NumericMatrix x) {
 //
 // popvec is the 1-based per-individual pop assignment vector that
 // match() against the file's pop list produces upstream (length nind,
-// values in 1..npop). NA / NaN genotypes in gmat are skipped via R's
-// ISNAN macro (matches R's `!is.na(x)`, which returns FALSE for both
-// NA and NaN but TRUE for +/-Inf). Using std::isfinite or arma::is_finite
-// here would diverge from the R version on Inf inputs -- harmless on
-// real genotype data (values in {0,1,2,NA}) but a real semantic
-// difference, so we use ISNAN for strict equivalence.
+// values in 1..npop). gmat is an integer dosage matrix; missing cells
+// hold NA_INTEGER (INT_MIN) and are skipped via `g != NA_INTEGER`, the
+// integer analogue of R's `!is.na(x)`. A double matrix passed by an
+// older caller is coerced to integer at the R/C++ boundary (Inf/NaN ->
+// NA_INTEGER with R's "NAs introduced by coercion" warning); real
+// genotype data is {0,1,2,NA} so this is value-preserving.
 //
 // Returns an (npop x nsnp) matrix of reference-allele frequencies in
 // [0, 1], with NaN where a (pop, snp) cell had zero valid genotypes
@@ -538,7 +538,13 @@ NumericVector row_prods(NumericMatrix x) {
 // undefined behavior at the sum_g(p, s) index step.
 //
 // [[Rcpp::export]]
-arma::mat cpp_gmat_to_aftable(arma::mat& gmat, arma::ivec& popvec, int nthreads = 1) {
+arma::mat cpp_gmat_to_aftable(arma::imat& gmat, arma::ivec& popvec, int nthreads = 1) {
+  // gmat is an integer dosage matrix in {0, 1, 2, NA_INTEGER}. arma::imat
+  // (vs the previous arma::mat) lets every reader's output pass through
+  // without R coercing it to a double matrix per block: the BED/
+  // PACKEDANCESTRYMAP/EIGENSTRAT readers return IntegerMatrix and PFILE's
+  // pgenlibr::ReadIntList is already integer. Missing is checked with
+  // == NA_INTEGER (INT_MIN), the integer analogue of R's !is.na.
   const int nind = (int)gmat.n_rows;
   const int nsnp = (int)gmat.n_cols;
   if ((int)popvec.n_elem != nind) {
@@ -562,19 +568,19 @@ arma::mat cpp_gmat_to_aftable(arma::mat& gmat, arma::ivec& popvec, int nthreads 
   mat cnt   = zeros<mat>(npop, nsnp);
 
   // Parallel over SNPs. Each thread writes a distinct column of sum_g
-  // and cnt (gmat and sum_g/cnt are arma::mat, column-major), so column
-  // s is a contiguous slice owned by one thread; no cross-thread writes
-  // collide. Rcpp::stop is not callable inside the parallel region;
-  // the popvec validation above runs serially before we enter. nthreads
-  // is the caller-supplied budget (see f4blockdat_from_geno in R/io.R).
+  // and cnt (sum_g/cnt are arma::mat, column-major), so column s is a
+  // contiguous slice owned by one thread; no cross-thread writes collide.
+  // Rcpp::stop is not callable inside the parallel region; the popvec
+  // validation above runs serially before we enter. nthreads is the
+  // caller-supplied budget (see f4blockdat_from_geno in R/io.R).
   // schedule(static): per-column work is uniform (one pass over nind).
   ADMIXTOOLS_OMP_PARALLEL_FOR(nthreads, static)
   for (int s = 0; s < nsnp; ++s) {
     for (int i = 0; i < nind; ++i) {
-      const double g = gmat(i, s);
-      if (!ISNAN(g)) {
+      const int g = gmat(i, s);
+      if (g != NA_INTEGER) {
         const int p = popvec(i) - 1;   // 1-based -> 0-based
-        sum_g(p, s) += g;
+        sum_g(p, s) += (double)g;
         cnt(p, s)   += 1.0;
       }
     }

--- a/src/cpp_readgeno.cpp
+++ b/src/cpp_readgeno.cpp
@@ -17,9 +17,13 @@ using namespace Rcpp;
 
 
 // [[Rcpp::export]]
-NumericMatrix cpp_read_packedancestrymap(String genofile, int nsnp, int nind, IntegerVector indvec,
+IntegerMatrix cpp_read_packedancestrymap(String genofile, int nsnp, int nind, IntegerVector indvec,
                                          int first, int last, bool transpose = false, bool verbose = true) {
 
+  // Returns an IntegerMatrix of genotype dosages in {0, 1, 2, NA_INTEGER},
+  // matching cpp_read_plink. Genotypes are integer-valued; an integer
+  // return halves the per-block buffer and lets the block feed
+  // cpp_gmat_to_aftable (arma::imat) without a double->int coercion copy.
   int val;
   long long len, bytespersnp;
   int readsnps = last - first;
@@ -46,8 +50,8 @@ NumericMatrix cpp_read_packedancestrymap(String genofile, int nsnp, int nind, In
     }
   }
 
-  NumericMatrix geno(transpose?nindused:readsnps, transpose?readsnps:nindused);
-  std::fill(geno.begin(), geno.end(), NA_REAL);
+  IntegerMatrix geno(transpose?nindused:readsnps, transpose?readsnps:nindused);
+  std::fill(geno.begin(), geno.end(), NA_INTEGER);
 
   // char* header = new char[bytespersnp];
   // in.seekg(0, std::ifstream::beg);
@@ -91,14 +95,14 @@ NumericMatrix cpp_read_packedancestrymap(String genofile, int nsnp, int nind, In
     if(!transpose) {
       for(int i = 0; i < nind; i++) {
         if(!indvec[i]) continue;
-        val = (double)tmp2[i];
+        val = tmp2[i];
         if(val != 3) geno(j, c) = val;
         c++;
       }
     } else {
       for(int i = 0; i < nind; i++) {
         if(!indvec[i]) continue;
-        val = (double)tmp2[i];
+        val = tmp2[i];
         if(val != 3) geno(c, j) = val;
         c++;
       }
@@ -285,9 +289,12 @@ List cpp_packedancestrymap_to_afs(String genofile, int nsnp, int nind, IntegerVe
 
 
 // [[Rcpp::export]]
-NumericMatrix cpp_read_eigenstrat(String genofile, int nsnp, int nind, IntegerVector indvec,
+IntegerMatrix cpp_read_eigenstrat(String genofile, int nsnp, int nind, IntegerVector indvec,
                                   int first, int last, bool transpose = false, bool verbose = true) {
 
+  // Returns an IntegerMatrix of genotype dosages in {0, 1, 2, NA_INTEGER},
+  // matching cpp_read_plink. See that function for the rationale; the
+  // missing sentinel in EIGENSTRAT is 9 (vs 3 in BED/PACKEDANCESTRYMAP).
   int val;
   long long len, bytespersnp;
   int readsnps = last - first;
@@ -309,8 +316,8 @@ NumericMatrix cpp_read_eigenstrat(String genofile, int nsnp, int nind, IntegerVe
     }
   }
 
-  NumericMatrix geno(transpose?nindused:readsnps, transpose?readsnps:nindused);
-  std::fill(geno.begin(), geno.end(), NA_REAL);
+  IntegerMatrix geno(transpose?nindused:readsnps, transpose?readsnps:nindused);
+  std::fill(geno.begin(), geno.end(), NA_INTEGER);
   in.seekg(first*bytespersnp, std::ifstream::beg);
   std::string tmp;
   for(int j = 0 ; j < readsnps; j++) {

--- a/src/cpp_readplink.cpp
+++ b/src/cpp_readplink.cpp
@@ -90,8 +90,15 @@ void decode_plink(unsigned char *out,
 
 
 // [[Rcpp::export]]
-NumericMatrix cpp_read_plink(String bedfile, int nsnp, int nind, IntegerVector indvec,
+IntegerMatrix cpp_read_plink(String bedfile, int nsnp, int nind, IntegerVector indvec,
                              int first, int last, bool transpose = false, bool verbose = true) {
+
+  // Returns an IntegerMatrix of genotype dosages in {0, 1, 2, NA_INTEGER}
+  // (4-byte ints vs 8-byte doubles), halving the largest per-block
+  // allocation in the f4 / qpadm hot loop. NA_INTEGER (= INT_MIN) is R's
+  // missing-integer; consumers check `!= NA_INTEGER` / R-side is.na, not
+  // ISNAN. The whole-genotype read_plink() path is unaffected: R promotes
+  // the matrix to double on fix_ploidy's `xmat[,c] <- xmat[,c]/2`.
 
   int val;
   long long len, bytespersnp;
@@ -123,8 +130,8 @@ NumericMatrix cpp_read_plink(String bedfile, int nsnp, int nind, IntegerVector i
     }
   }
 
-  NumericMatrix geno(transpose?nindused:readsnps, transpose?readsnps:nindused);
-  std::fill(geno.begin(), geno.end(), NA_REAL);
+  IntegerMatrix geno(transpose?nindused:readsnps, transpose?readsnps:nindused);
+  std::fill(geno.begin(), geno.end(), NA_INTEGER);
 
   in.seekg(3+first*bytespersnp, std::ifstream::beg);
   unsigned char* tmp = new unsigned char[bytespersnp + 1];
@@ -163,14 +170,14 @@ NumericMatrix cpp_read_plink(String bedfile, int nsnp, int nind, IntegerVector i
     if(!transpose) {
       for(int i = 0; i < nind; i++) {
         if(!indvec[i]) continue;
-        val = (double)tmp2[i];
+        val = tmp2[i];
         if(val != 3) geno(j, c) = val;
         c++;
       }
     } else {
       for(int i = 0; i < nind; i++) {
         if(!indvec[i]) continue;
-        val = (double)tmp2[i];
+        val = tmp2[i];
         if(val != 3) geno(c, j) = val;
         c++;
       }

--- a/tests/testthat/test-cpp-aftable-omp.R
+++ b/tests/testthat/test-cpp-aftable-omp.R
@@ -77,7 +77,12 @@ test_that("cpp_aftable_to_dstatden: serial == parallel (bitwise)", {
 test_that("cpp_gmat_to_aftable: serial == parallel (bitwise)", {
   withr::with_seed(20260525L, {
     nind = 200L; nsnp = 500L; npop = 8L
-    gmat = matrix(sample(c(0, 1, 2, NA_real_), nind * nsnp, replace = TRUE,
+    # Integer dosages in {0, 1, 2, NA_INTEGER}: this is what the readers hand
+    # the kernel (cpp_read_plink -> IntegerMatrix, pgenlibr::ReadIntList ->
+    # integer), and what cpp_gmat_to_aftable's arma::imat signature takes
+    # natively. Sampling from a double vector would instead exercise R's
+    # double->integer coercion fallback at the boundary, not the native path.
+    gmat = matrix(sample(c(0L, 1L, 2L, NA_integer_), nind * nsnp, replace = TRUE,
                          prob = c(0.3, 0.4, 0.25, 0.05)),
                   nrow = nind, ncol = nsnp)
     popvec = sample.int(npop, nind, replace = TRUE)

--- a/tests/testthat/test-cpp-gmat-to-aftable.R
+++ b/tests/testthat/test-cpp-gmat-to-aftable.R
@@ -2,21 +2,24 @@
 #
 # Mathematical equivalence to the R one-liner is the headline contract:
 #   rowsum(gmat, popvec, na.rm = TRUE) / rowsum((!is.na(gmat))+0, popvec) / 2
-# The C++ kernel uses R's ISNAN (matches !is.na) rather than std::isfinite,
-# so it's strictly equivalent to R on Inf inputs too (Inf flows through to
-# the sum, matching R).
+# The C++ kernel takes an integer dosage matrix in {0, 1, 2, NA_INTEGER}
+# (the BED and PFILE readers produce one natively) and checks g != NA_INTEGER,
+# the integer analogue of R's !is.na.
 
 # Reference R implementation, the one-liner that the C++ replaces.
 .r_gmat_to_aftable = function(gmat, popvec) {
   rowsum(gmat, popvec, na.rm = TRUE) / rowsum((!is.na(gmat))+0, popvec) / 2
 }
 
-# Build a realistic synthetic genotype matrix: values in {0, 1, 2, NA}.
+# Build a realistic synthetic genotype matrix: integer values in {0, 1, 2, NA}.
+# Integer storage matches what the readers now hand the kernel (cpp_read_plink
+# -> IntegerMatrix, pgenlibr::ReadIntList -> integer), so the equivalence tests
+# exercise the native integer path rather than R's double->integer coercion.
 .synthetic_gmat = function(nind, nsnp, na_frac = 0.1, seed = 12345L) {
   withr::with_seed(seed, {
     g = sample(0:2, nind * nsnp, replace = TRUE)
-    g[sample.int(length(g), size = round(length(g) * na_frac))] = NA_real_
-    matrix(as.numeric(g), nrow = nind, ncol = nsnp)
+    g[sample.int(length(g), size = round(length(g) * na_frac))] = NA_integer_
+    matrix(as.integer(g), nrow = nind, ncol = nsnp)
   })
 }
 
@@ -79,27 +82,28 @@ test_that("cpp_gmat_to_aftable handles single-pop / single-SNP / single-ind boun
   expect_equal(cpp_out, r_out, tolerance = 0)
 })
 
-test_that("cpp_gmat_to_aftable preserves R's !is.na behavior on Inf inputs (ISNAN, not isfinite)", {
-  # The PR uses ISNAN(g) (matches R's !is.na) rather than std::isfinite,
-  # so +/-Inf is treated as a valid genotype (Inf flows through to the
-  # sum, matching the R one-liner). std::isfinite would have excluded
-  # Inf and diverged from R.
+test_that("cpp_gmat_to_aftable treats NA_INTEGER as missing (matches R's !is.na contract)", {
+  # gmat arrives as an integer matrix (the BED and PFILE readers produce
+  # IntegerMatrix natively; a double matrix from an older caller gets
+  # auto-coerced by R, with Inf -> NA per as.integer's contract). The C++
+  # side checks `g != NA_INTEGER` rather than ISNAN(g); both are the
+  # equivalent R `!is.na()` semantic on their respective types.
   gmat = matrix(c(
-    0,   1,
-    Inf, 2,
-    1,   NA_real_
+    0L, 1L,
+    NA_integer_, 2L,
+    1L, NA_integer_
   ), nrow = 3, byrow = TRUE)
   popvec = c(1L, 1L, 2L)
 
   r_out   = .r_gmat_to_aftable(gmat, popvec)
   cpp_out = admixtools:::cpp_gmat_to_aftable(gmat, popvec)
   r_out = unname(r_out)
-  # Pop 1 col 1: (0 + Inf) / 2 / 2 = Inf  (Inf is included in both versions)
+  # Pop 1 col 1: 0 / 1 / 2 = 0      (NA at row 2 dropped)
   # Pop 1 col 2: (1 + 2) / 2 / 2 = 0.75
   # Pop 2 col 1: 1 / 1 / 2 = 0.5
   # Pop 2 col 2: NA -> 0/0 -> NaN
   expect_equal(cpp_out, r_out, tolerance = 0)
-  expect_true(is.infinite(cpp_out[1, 1]))
+  expect_equal(cpp_out[1, 1], 0)
   expect_equal(cpp_out[1, 2], 0.75)
   expect_true(is.nan(cpp_out[2, 2]))
 })


### PR DESCRIPTION
## Summary

The four block-wise genotype readers return an `IntegerMatrix` in `{0, 1, 2, NA_INTEGER}` instead of a `NumericMatrix` in `{0, 1, 2, NA_REAL}`, and `cpp_gmat_to_aftable` takes `arma::imat` to accept them natively:

| Reader | Format |
|---|---|
| `cpp_read_plink` | PLINK `.bed` |
| `cpp_read_packedancestrymap` | PACKEDANCESTRYMAP `.geno` |
| `cpp_read_eigenstrat` | EIGENSTRAT `.geno` |
| (`pgenlibr::ReadIntList`) | PFILE — already integer |

Genotype dosages are integer-valued, so the previous `double` representation used 8 bytes per cell where 4 suffice — doubling the largest single allocation in the per-block f4 / qpadm read loop (once per block across the block partition). Making *every* reader integer-native (rather than just plink) means no format pays a `double -> int` coercion at the `read -> cpp_gmat_to_aftable` boundary, and the saving applies uniformly.

The missing-value check moves from `ISNAN(g)` to `g != NA_INTEGER`, the integer analogue of R's `!is.na`.

## Impact

Measured on production-shape panels (~600 individuals x 1.135M autosomal SNPs) on x86_64 Linux (R 4.6.0, gcc 13.3, OpenBLAS, `OPENBLAS_NUM_THREADS=1`), 16-core:

- **Peak R memory attributed: -26%** on a qpadm-from-geno run (the robust, structural benefit -- a guaranteed 4-vs-8-byte saving on the genotype buffer).
- **Wall: -11% to -23%** depending on workload, most on the PFILE path. The wall fraction varies with core count and the OpenMP-parallel share of the run, so memory is the headline and wall is the follow-on.

All output is bit-identical -- see below.

## Correctness

Genotype values `{0, 1, 2, NA}` map losslessly between `double` and `int`, so this is purely a storage-type change with no numeric effect. Verified end-to-end, master vs this branch, full-object `identical()`, on all four on-disk formats:

- `qpadm` and `qpdstat` on **BED** -- identical.
- `qpadm` on **PFILE** -- identical.
- `qpdstat` on **EIGENSTRAT** -- identical.
- `qpdstat` on **PACKEDANCESTRYMAP** -- identical. (The package ships no example EIGENSTRAT/PACKEDANCESTRYMAP data; both were validated on synthetic panels. The packed-binary panel was additionally cross-checked against the same genotypes read via EIGENSTRAT, confirming the reader decodes them faithfully.)
- Full test suite: identical pass/fail/skip totals to master (no new failures).

Other consumers are unaffected because R promotes an integer matrix to `double` on any fractional arithmetic:
- the whole-genotype readers (`read_plink` / `read_eigenstrat` / `read_packedancestrymap` -> `fix_ploidy`'s `xmat[,c] <- xmat[,c]/2`); pseudohaploid columns are `{0,2} -> {0,1}` whole numbers, so the result is identical;
- the in-memory EIGENSTRAT AFS path (`geno/(3-ploidy)`, `!is.na`, `unique(na.omit())`).

The `*_to_afs` C++ functions, which return fractional allele frequencies, are deliberately left as `NumericMatrix`.

## Test plan

- [x] BED + PFILE + EIGENSTRAT + PACKEDANCESTRYMAP `qpadm`/`qpdstat` bit-identical to master (full-object `identical()`).
- [x] Full `testthat` suite: identical totals vs master, zero new failures.
- [x] `R CMD check`: clean (1 pre-existing NOTE -- CRAN-feasibility metadata, unrelated to this change).
- [x] Builds on x86_64 Linux gcc and aarch64 macOS clang.

## Note

The Inf-input edge case in `test-cpp-gmat-to-aftable.R` no longer applies (Inf cannot exist in an integer matrix; a `double` input with Inf coerces to `NA_INTEGER` per `as.integer`). It is replaced with an `NA_INTEGER`-as-missing equivalence test.
