### PR TITLE
perf(qpgraph): pass vertex ids to get_edge_ids in path weight construction

### DIFF
--- a/R/qpgraph.R
+++ b/R/qpgraph.R
@@ -18,7 +18,9 @@ graph_to_pwts = function(graph, leaves) {
     target = names(tail(allpaths[[i]],1))
     ln = length(allpaths[[i]])
     pth2 = allpaths[[i]][c(1, 1+rep(seq_len(ln-2), each=2), ln)]
-    rowind = as.vector(E(graph)[igraph::get_edge_ids(graph, igraph::as_ids(pth2))])
+    # pth2 is already an integer vertex sequence, so pass the ids directly.
+    # as_ids() returns names, forcing igraph to re-resolve them via vertex_attr on every path.
+    rowind = as.vector(E(graph)[igraph::get_edge_ids(graph, as.numeric(pth2))])
     pwts[rowind,target] = pwts[rowind,target] + 1/pathcounts[target]
   }
 
@@ -71,7 +73,9 @@ graph_to_weightind = function(graph) {
   normedges = setdiff(1:length(E(graph)), admixedges)
   paths = all_simple_paths(graph, root, leaves, mode='out')
   ends = sapply(paths, tail, 1)
-  edge_per_path = paths %>% map(expand_path) %>% map(~igraph::get_edge_ids(graph, igraph::as_ids(.)))
+  # pass the integer vertex ids directly; as_ids() would return names and force
+  # igraph to re-resolve them via vertex_attr on every path.
+  edge_per_path = paths %>% map(expand_path) %>% map(~igraph::get_edge_ids(graph, as.numeric(.)))
   weight_per_path = edge_per_path %>% map(~(which(admixedges %in% .)))
 
   path_edge_table = do.call(rbind, lapply(seq_len(length(weight_per_path)),


### PR DESCRIPTION
## What

`graph_to_pwts` and `graph_to_weightind` build, for each root to leaf path, the vector of edge ids the path traverses. Both did this with

```r
igraph::get_edge_ids(graph, igraph::as_ids(pth))
```

`pth` is already an integer vertex sequence returned by `all_simple_paths`. `as_ids` converts it to vertex names, and `get_edge_ids` then resolves those names back to ids internally. That name to id resolution makes igraph look the names up against the vertex name attribute (via `vertex_attr`) once per path, once per graph scored.

This PR passes the vertex ids straight through instead.

```r
igraph::get_edge_ids(graph, as.numeric(pth))
```

That is the whole change, two lines plus comments.

## Why

Instrumenting a `find_graphs` run, vertex name resolution (`V` and `vertex_attr`) accounts for about 85 percent of all igraph accessor calls, and these two functions are the single largest contributor because they run the per path loop on every graph the search scores. The two lines here are the only `get_edge_ids` call sites in the package, and both functions are reached only through `qpgraph` (and through it `find_graphs` and the `qpgraph_resample` helpers).

## Correctness

The substitution is byte for byte identical. The name to id round trip is a loss free bijection inversion whenever vertex names are unique, which admixture graphs always are by construction (`graph_from_edgelist` on a unique symbol set, and the only vertex adding helpers name new nodes uniquely).

Verified as follows.

| check | scope | result |
| --- | --- | --- |
| `graph_to_pwts` and `graph_to_weightind` output | 1680 random graphs, 4 to 14 leaves, 0 to 5 admixture edges | identical, 0 mismatches |
| full `qpgraph` output (score, edge weights, f3 z) | 38 graph and f2 combinations incl. real data | identical, max diff exactly 0 |
| per path edge ids | 8700 paths over 900 graphs | identical |
| package test suite | functional, property, roundtrip, identifiability, sampled tips | identical pass before and after |
| winner recovery, end to end | 5 graph search cases, 8 seeds each, two platforms | winners identical |

The one input that would break the equivalence, duplicate vertex names, was constructed by hand and confirmed unreachable for admixture graph inputs.

## Performance

Microbenchmark on a quiet pinned Linux instance, three interleaved rounds, median per call.

| graph | leaves | graph_to_pwts | graph_to_weightind |
| --- | --- | --- | --- |
| 6 leaf tree | 6 | 5.4 percent faster | 4.3 percent faster |
| 6 leaf, 1 admix | 6 | 5.2 | 5.5 |
| 8 leaf, 2 admix | 8 | 6.5 | 4.9 |
| 9 leaf, 3 admix | 9 | 6.0 | 2.2 |
| 11 leaf, 2 admix | 11 | 6.5 | 8.3 |
| 13 leaf, 3 admix | 13 | 11.8 | 11.4 |

The two functions are about 7 and 6 percent faster on average, and the gain grows with leaf count because larger graphs enumerate more paths. The realized speedup of a full `qpgraph` evaluation is about 3 to 4 percent, since the numeric optimizer it feeds is unaffected. Across one `find_graphs` run the change removes about 12 percent of all igraph accessor calls.
