### PR TITLE
perf(toposearch): derive in and out degree without naming the result

### DIFF
--- a/R/toposearch.R
+++ b/R/toposearch.R
@@ -32,13 +32,24 @@ doublefactorial = function(n) {
   out
 }
 
+# In/out degree as plain unnamed integer vectors, indexed by vertex id.
+# Equivalent to unname(igraph::degree(graph, mode=)), but avoids degree()
+# naming its result on a named graph, which forces a vertex_attr lookup that
+# the hot validators below never use. as_edgelist(names=FALSE) returns id pairs
+# (no name resolution), and tabulate counts targets (in) and sources (out).
+inout_degree = function(graph) {
+  el = igraph::as_edgelist(graph, names = FALSE)
+  n  = igraph::vcount(graph)
+  list(indeg = tabulate(el[, 2], n), outdeg = tabulate(el[, 1], n))
+}
+
 #' Count number of admixture nodes
 #'
 #' @export
 #' @param graph An admixture graph
 #' @return Number of admixture nodes
 numadmix = function(graph) {
-  sum(degree(graph, mode='in') == 2)
+  sum(inout_degree(graph)$indeg == 2)
 }
 
 #' Test if an admixture graph is valid
@@ -48,8 +59,9 @@ numadmix = function(graph) {
 #' @return `TRUE` if graph is valid, otherwise `FALSE`
 is_valid = function(graph) {
 
-  indegree = igraph::degree(graph, mode = 'in')
-  outdegree = igraph::degree(graph, mode = 'out')
+  deg = inout_degree(graph)
+  indegree = deg$indeg
+  outdegree = deg$outdeg
 
   igraph::is_simple(graph) &&
     igraph::is_connected(graph) &&
@@ -62,8 +74,9 @@ is_valid = function(graph) {
 }
 
 is_simplified = function(graph) {
-  indeg = degree(graph, mode = 'in')
-  outdeg = degree(graph, mode = 'out')
+  deg = inout_degree(graph)
+  indeg = deg$indeg
+  outdeg = deg$outdeg
   sum(indeg == 1 & outdeg == 1) == 0 && max(indeg + outdeg) == 3 && igraph::is_simple(graph)
 }
 
@@ -82,11 +95,11 @@ edges_to_igraph = function(edges) {
 #' @param graph An admixture graph
 #' @return Population names
 get_leafnames = function(graph) {
-  graph %>% V %>% {names(which(degree(graph, ., mode='out') == 0))}
+  igraph::vertex_attr(graph, 'name')[inout_degree(graph)$outdeg == 0]
 }
 
 get_leaves = function(graph) {
-  graph %>% V %>% {.[degree(graph, ., mode='out') == 0]}
+  igraph::V(graph)[inout_degree(graph)$outdeg == 0]
 }
 
 get_leaves2 = function(graph) {
@@ -97,7 +110,7 @@ get_leaves2 = function(graph) {
 
 
 get_root = function(graph) {
-  root = V(graph)[igraph::degree(graph, mode = 'in') == 0]
+  root = igraph::V(graph)[inout_degree(graph)$indeg == 0]
   #if(length(root) != 1) stop(paste0('Root problem ', paste0(names(root), collapse = ' ')))
   root
 }


### PR DESCRIPTION
## What

Six small graph helpers in the find_graphs hot path computed vertex degrees with `igraph::degree(graph, mode=)`.

```r
indegree  = igraph::degree(graph, mode = 'in')
outdegree = igraph::degree(graph, mode = 'out')
```

On a named graph `degree()` names its result vector by vertex, which forces a `vertex_attr` lookup. None of these functions read those names; they reduce the degree vector with `sum`, `all`, `any`, `which`, or use it as a logical index into `V()`. The name lookup is pure overhead.

This PR adds one internal helper that derives both degrees from the unnamed edge list, and routes the six functions through it.

```r
inout_degree = function(graph) {
  el = igraph::as_edgelist(graph, names = FALSE)
  n  = igraph::vcount(graph)
  list(indeg = tabulate(el[, 2], n), outdeg = tabulate(el[, 1], n))
}
```

`as_edgelist(names=FALSE)` returns integer endpoint ids with no name resolution, and `tabulate` counts targets (in) and sources (out). The six functions touched are `numadmix`, `is_valid`, `is_simplified`, `get_leafnames`, `get_leaves` and `get_root`.

## Why

After the earlier `get_edge_ids` change, instrumenting a `find_graphs` run showed that `degree()` output naming inside these validators was the largest remaining source of igraph name resolution overhead. `is_valid`, `is_simplified` and `numadmix` run on essentially every candidate graph the search evaluates, and `get_leafnames` has about 90 call sites across the package. Each `degree()` call paid for a vertex name vector that was immediately discarded.

## Correctness

Output is identical at every observable boundary. The return types are unchanged (`numadmix` an integer count, the two validators a logical, `get_leafnames` a character vector, `get_leaves` and `get_root` an `igraph.vs`).

| check | scope | result |
| --- | --- | --- |
| six functions vs the old definitions | 1770 graph shapes, 4 to 14 leaves, 0 to 5 admixture edges, both outgroup modes | 14160 comparisons, 0 mismatches |
| `find_graphs` winners and `qpgraph` output | 27 runs across simulated and real panel data | identical, result object md5 match |
| paired winner recovery, end to end | 5 graph search cases, 8 seeds each, two platforms | winners identical, 100 percent of seeds |
| package test suite | functional, property, roundtrip, identifiability | identical pass before and after |

`tabulate` over the unnamed edge list equals the degree of a simple directed graph for every vertex, which admixture graphs always are by construction. The helper emulates only the in and out directions, never the combined direction, so the one case where the two could differ (a self loop counted twice in the combined direction) is never requested and is also unreachable for admixture graph inputs. The helper returns integer counts where `degree` returns doubles, which is value identical for all six callers since each consumes the result only through arithmetic and logical comparisons.

## Performance

Function microbenchmark on a quiet pinned Linux instance, median per call over a 6 to 13 leaf battery.

| function | master | branch | speedup |
| --- | --- | --- | --- |
| numadmix | 219 us | 25 us | 89 percent faster |
| is_valid | 623 us | 124 us | 80 percent faster |
| is_simplified | 601 us | 30 us | 95 percent faster |
| get_leafnames | 354 us | 71 us | 80 percent faster |
| get_leaves | 986 us | 346 us | 65 percent faster |
| get_root | 1197 us | 376 us | 69 percent faster |

End to end across one `find_graphs` run the realized wall improvement is a few percent, since the C++ optimizer the search feeds is unaffected. On the two lowest variance cases the paired improvement is about 5 percent and clearly significant (a 6 leaf single admixture case at 5.1 percent, p well below 0.001, and a real 6 population panel case at 4.9 percent, p well below 0.001). The other cases move in the same direction within wider confidence intervals.
