### PR TITLE
perf(qpgraph): cut per-graph allocation in path weight construction

### DIFF
--- a/R/qpgraph.R
+++ b/R/qpgraph.R
@@ -26,7 +26,10 @@ graph_to_pwts = function(graph, leaves, root = NULL, admixedges = NULL) {
     pth2 = pth[c(1, 1+rep(seq_len(ln-2), each=2), ln)]
     # pth2 is already an integer vertex sequence, so pass the ids directly.
     # as_ids() returns names, forcing igraph to re-resolve them via vertex_attr on every path.
-    rowind = as.vector(E(graph)[igraph::get_edge_ids(graph, as.numeric(pth2))])
+    # get_edge_ids already returns the integer edge ids that index pwts rows;
+    # wrapping them in E(graph)[...] only to as.vector back allocates an edge
+    # sequence per path. Index by the ids directly (rowind names are unused).
+    rowind = igraph::get_edge_ids(graph, as.numeric(pth2))
     pwts[rowind,target] = pwts[rowind,target] + 1/pathcounts[target]
   }
 
@@ -85,19 +88,31 @@ graph_to_weightind = function(graph, root = NULL, admixedges = NULL) {
   ends = sapply(paths, tail, 1)
   # pass the integer vertex ids directly; as_ids() would return names and force
   # igraph to re-resolve them via vertex_attr on every path.
-  edge_per_path = paths %>% map(expand_path) %>% map(~igraph::get_edge_ids(graph, as.numeric(.)))
-  weight_per_path = edge_per_path %>% map(~(which(admixedges %in% .)))
+  edge_per_path = lapply(paths, function(p) igraph::get_edge_ids(graph, as.numeric(expand_path(p))))
+  weight_per_path = lapply(edge_per_path, function(e) which(admixedges %in% e))
 
-  path_edge_table = do.call(rbind, lapply(seq_len(length(weight_per_path)),
-                                          function(i) tibble(path=i, edge=c(edge_per_path[[i]])))) %>%
-    mutate(edge2 = match(edge, normedges)) %>% filter(!is.na(edge2)) %>%
-    mutate(leaf = as.vector(ends[path]), leaf2 = match(leaf, leaves)) %>%
-    left_join(enframe(c(table(ends))) %>% transmute(leaf=as.numeric(name), numpaths=value), by='leaf') %>%
-    group_by(leaf2, edge2) %>% mutate(cnt = n(), keep = cnt < numpaths) %>% filter(keep) %>% as.matrix
+  # path_edge_table: one row per (path, edge), keeping only edges that lie on
+  # some but not all of a leaf's paths (cnt < numpaths). Built in base R to
+  # avoid per-graph dplyr allocation; byte-identical to the former pipeline of
+  # tibble / mutate / left_join / group_by / filter / as.matrix.
+  path  = rep(seq_along(edge_per_path), lengths(edge_per_path))
+  edge  = unlist(edge_per_path); if(is.null(edge)) edge = integer(0)
+  edge2 = match(edge, normedges); ok = !is.na(edge2)
+  path = path[ok]; edge = edge[ok]; edge2 = edge2[ok]
+  leaf  = as.vector(ends[path]); leaf2 = match(leaf, leaves)
+  numpaths = as.vector(table(ends)[as.character(leaf)])
+  cnt   = ave(seq_along(edge2), paste(leaf2, edge2, sep = '\r'), FUN = length)
+  keep  = cnt < numpaths
+  path_edge_table = cbind(path = path, edge = edge, edge2 = edge2, leaf = leaf,
+                          leaf2 = leaf2, numpaths = numpaths, cnt = cnt,
+                          keep = as.numeric(keep))[keep, , drop = FALSE]
 
-  path_admixedge_table = do.call(rbind, lapply(seq_len(length(weight_per_path)),
-                                               function(i) tibble(path=i, admixedge=c(weight_per_path[[i]])))) %>%
-    as.matrix
+  path_admixedge_table = cbind(path = rep(seq_along(weight_per_path), lengths(weight_per_path)),
+                               admixedge = as.integer(unlist(weight_per_path)))
+  # match the former as.matrix(empty tibble) storage mode on zero-row results
+  # (only reachable for nadmix==0 graphs, which qpgraph never routes here)
+  if(nrow(path_edge_table) == 0L) storage.mode(path_edge_table) <- 'logical'
+  if(nrow(path_admixedge_table) == 0L) storage.mode(path_admixedge_table) <- 'logical'
   list(path_edge_table, path_admixedge_table, length(paths))
 }
 

--- a/tests/testthat/test-graph-helper-contracts.R
+++ b/tests/testthat/test-graph-helper-contracts.R
@@ -160,3 +160,72 @@ test_that("graph_to_pwts is invariant to vertex id assignment", {
   # confirm the battery actually exercised a changed id assignment
   expect_true(saw_relabel)
 })
+
+# ---- Tier 2  graph_to_weightind base-R index tables ------------------------
+# The dplyr pipeline that built path_edge_table and path_admixedge_table was
+# replaced with base-R vector ops. The output must be unchanged. Pin it two
+# ways: an independent oracle rebuilds path_edge_table (the cnt < numpaths keep
+# rule) from the raw edge list, and the empty (tree) case is checked explicitly
+# because qpgraph never routes a zero-admixture graph here so nothing else
+# exercises the zero-row branch.
+
+test_that("graph_to_weightind path_edge_table matches an independent oracle", {
+  # Recompute path_edge_table from scratch: resolve each path's edges from the
+  # unnamed edge list, drop admixture edges, and keep (path, edge) rows for
+  # edges that lie on some but not all of a leaf's paths.
+  oracle <- function(g) {
+    root <- admixtools:::get_root(g)
+    leaves <- admixtools:::get_leaves(g)
+    nE <- length(igraph::E(g))
+    admixnodes <- which(igraph::degree(g, mode = 'in') == 2)
+    admixedges <- unlist(igraph::incident_edges(g, admixnodes, mode = 'in'))
+    normedges <- setdiff(seq_len(nE), admixedges)
+    elf <- igraph::as_edgelist(g, names = FALSE)
+    edge_of <- function(a, b) which(elf[, 1] == a & elf[, 2] == b)
+    paths <- igraph::all_simple_paths(g, root, leaves, mode = 'out')
+    ends <- vapply(paths, function(p) as.numeric(p)[length(p)], numeric(1))
+    rows <- list()
+    for (i in seq_along(paths)) {
+      v <- as.numeric(paths[[i]])
+      eids <- vapply(seq_len(length(v) - 1), function(k) edge_of(v[k], v[k + 1]), integer(1))
+      for (e in eids) {
+        e2 <- match(e, normedges)
+        if (is.na(e2)) next
+        rows[[length(rows) + 1]] <- c(path = i, edge2 = e2, leaf2 = match(ends[i], as.numeric(leaves)))
+      }
+    }
+    m <- do.call(rbind, rows)
+    if (is.null(m)) return(m)
+    # cnt per (leaf2, edge2)
+    key <- paste(m[, 'leaf2'], m[, 'edge2'])
+    cnt <- ave(seq_len(nrow(m)), key, FUN = length)
+    np_per_row <- as.vector(table(ends)[as.character(ends[m[, 'path']])])
+    m[cnt < np_per_row, c('path', 'edge2', 'leaf2'), drop = FALSE]
+  }
+  checked <- 0
+  for (case in graph_battery) {
+    g <- case$g
+    if (numadmix(g) == 0) next
+    wi <- admixtools:::graph_to_weightind(g)
+    got <- wi[[1]][, c('path', 'edge2', 'leaf2'), drop = FALSE]
+    exp <- oracle(g)
+    ord <- function(x) x[order(x[, 'path'], x[, 'edge2'], x[, 'leaf2']), , drop = FALSE]
+    expect_equal(unname(ord(got)), unname(ord(exp)), info = case$label)
+    checked <- checked + 1
+  }
+  expect_gt(checked, 0)
+})
+
+test_that("graph_to_weightind returns empty tables with a stable shape on trees", {
+  # A zero-admixture graph yields no surviving (path, edge) rows: every edge is
+  # on all (= 1) of its leaf's paths. qpgraph never calls weightind on such a
+  # graph, but the zero-row contract (columns and storage mode) is pinned here.
+  tree <- graph_battery[[which(vapply(graph_battery, function(c) numadmix(c$g) == 0, logical(1)))[1]]]$g
+  wi <- admixtools:::graph_to_weightind(tree)
+  expect_equal(nrow(wi[[1]]), 0L)
+  expect_equal(nrow(wi[[2]]), 0L)
+  expect_identical(colnames(wi[[1]]),
+                   c('path', 'edge', 'edge2', 'leaf', 'leaf2', 'numpaths', 'cnt', 'keep'))
+  expect_identical(colnames(wi[[2]]), c('path', 'admixedge'))
+  expect_type(wi[[3]], 'integer')
+})


### PR DESCRIPTION
## Summary

`graph_to_weightind` and `graph_to_pwts` run once per graph scored, and `find_graphs` scores thousands of graphs per search, so they are the two hottest R allocation sites. This reworks both to allocate far less, with no change to any result.

**`graph_to_weightind`** built its two index tables with a per path tibble, then `mutate`, `left_join`, `group_by`, and `filter`, then `as.matrix`. That pipeline allocated a large amount of short lived memory on every call. It is replaced with base R vector operations and `cbind`, with `ave` for the group sizes that drive the `cnt < numpaths` keep rule, and the `purrr` maps over paths become `lapply`.

**`graph_to_pwts`** indexed the weight matrix with `as.vector(E(graph)[get_edge_ids(graph, path)])`. `get_edge_ids` already returns the integer edge ids that are the row indices, so the `E(graph)` wrapper only built an edge sequence per path and then unwrapped it back to integers. The ids are used directly now.

Both helpers are internal and reached only through `qpgraph`.

## Correctness

Output is byte for byte identical. Validation, with each side run in a separate process and inputs generated once then replayed across both builds:

* `graph_to_weightind` index matrices match the former pipeline under `identical()` across more than three thousand random graphs (four to fourteen leaves, zero to six admixture edges). This includes pure trees, where both intermediate matrices are empty and now share the same storage mode.
* `graph_to_pwts` matrices match across more than fourteen hundred random graphs. An adversarial pass confirmed that `get_edge_ids` never returns a zero (no edge) id for a valid path across every path of every graph, which is the only case where the old wrapper form could have differed.
* Full `qpgraph` output (score, edge weights, f3 z, and a serialized digest of the whole return object) and `find_graphs` winners (topology, score, number of graphs explored) match across the simulated cases and one real data case.
* The change set, checked by deparsing both installed namespaces, is exactly these two functions and nothing else.
* The package test suite passes. This change also adds two contract tests for `graph_to_weightind`, in the style of the existing path weight optimization tests: an independent oracle that rebuilds the index tables from the raw edge list, and a tree case that pins the empty table contract.

Negative controls confirm the checks detect a one part in a billion perturbation.

## Performance

Measured on Linux with one thread pinned, on a representative two admixture search, with the new and old code run back to back per seed across seven seeds and both run orders. The change reduces `find_graphs` wall time by about thirty percent (every seed between twenty eight and thirty percent, with the two run orders agreeing, so this is not a measurement order effect). Total allocation drops by about twenty three percent and time spent in garbage collection by about a third.

The wall saving is larger than the garbage collection saving alone. The reason is that the old `graph_to_weightind` ran a full dplyr pipeline on every one of the hundreds of graphs scored in a search, and dplyr carries a large fixed per call cost from non standard evaluation and grouped frame construction that is mostly compute rather than memory. Removing that, together with the `graph_to_pwts` edge id change, is where most of the wall time comes back. The two rewritten functions account for almost all of it.

This continues the path weight optimizations merged in 163, 164, and 165, in the same file.
