### PR TITLE
refactor(qpgraph): emit only the consumed columns from graph_to_weightind

### DIFF
--- a/R/qpgraph.R
+++ b/R/qpgraph.R
@@ -92,27 +92,21 @@ graph_to_weightind = function(graph, root = NULL, admixedges = NULL) {
   weight_per_path = lapply(edge_per_path, function(e) which(admixedges %in% e))
 
   # path_edge_table: one row per (path, edge), keeping only edges that lie on
-  # some but not all of a leaf's paths (cnt < numpaths). Built in base R to
-  # avoid per-graph dplyr allocation; byte-identical to the former pipeline of
-  # tibble / mutate / left_join / group_by / filter / as.matrix.
+  # some but not all of a leaf's paths (cnt < numpaths). Only path, edge2 and
+  # leaf2 are emitted: those are the three columns the consumers read
+  # (cpp_fill_pwts by position, fill_pwts by name). numpaths, cnt and the raw
+  # edge / leaf are intermediate values used only to compute the keep mask.
   path  = rep(seq_along(edge_per_path), lengths(edge_per_path))
-  edge  = unlist(edge_per_path); if(is.null(edge)) edge = integer(0)
-  edge2 = match(edge, normedges); ok = !is.na(edge2)
-  path = path[ok]; edge = edge[ok]; edge2 = edge2[ok]
+  edge2 = match(unlist(edge_per_path), normedges); ok = !is.na(edge2)
+  path = path[ok]; edge2 = edge2[ok]
   leaf  = as.vector(ends[path]); leaf2 = match(leaf, leaves)
   numpaths = as.vector(table(ends)[as.character(leaf)])
   cnt   = ave(seq_along(edge2), paste(leaf2, edge2, sep = '\r'), FUN = length)
   keep  = cnt < numpaths
-  path_edge_table = cbind(path = path, edge = edge, edge2 = edge2, leaf = leaf,
-                          leaf2 = leaf2, numpaths = numpaths, cnt = cnt,
-                          keep = as.numeric(keep))[keep, , drop = FALSE]
+  path_edge_table = cbind(path = path, edge2 = edge2, leaf2 = leaf2)[keep, , drop = FALSE]
 
   path_admixedge_table = cbind(path = rep(seq_along(weight_per_path), lengths(weight_per_path)),
                                admixedge = as.integer(unlist(weight_per_path)))
-  # match the former as.matrix(empty tibble) storage mode on zero-row results
-  # (only reachable for nadmix==0 graphs, which qpgraph never routes here)
-  if(nrow(path_edge_table) == 0L) storage.mode(path_edge_table) <- 'logical'
-  if(nrow(path_admixedge_table) == 0L) storage.mode(path_admixedge_table) <- 'logical'
   list(path_edge_table, path_admixedge_table, length(paths))
 }
 

--- a/src/cpp_qpgraph.cpp
+++ b/src/cpp_qpgraph.cpp
@@ -59,9 +59,10 @@ arma::mat cpp_fill_pwts(arma::mat& pwts, const arma::vec& weights,
     if(admixedge % 2 == 0) pathweights(path) *= weights(admixedge/2);
     else pathweights(path) *= 1-weights(admixedge/2);
   }
+  // path_edge_table columns are path(0), edge2(1), leaf2(2)
   for(int i=0; i<path_edge_table.n_rows; i++) {
-    row = path_edge_table(i, 2)-1;
-    column = path_edge_table(i, 4)-1;
+    row = path_edge_table(i, 1)-1;
+    column = path_edge_table(i, 2)-1;
     path = path_edge_table(i, 0)-1;
     elem = row + pwts.n_rows*column;
     pwtsfill(elem) += pathweights(path);

--- a/tests/testthat/test-graph-helper-contracts.R
+++ b/tests/testthat/test-graph-helper-contracts.R
@@ -219,13 +219,12 @@ test_that("graph_to_weightind path_edge_table matches an independent oracle", {
 test_that("graph_to_weightind returns empty tables with a stable shape on trees", {
   # A zero-admixture graph yields no surviving (path, edge) rows: every edge is
   # on all (= 1) of its leaf's paths. qpgraph never calls weightind on such a
-  # graph, but the zero-row contract (columns and storage mode) is pinned here.
+  # graph, but the zero-row column contract is pinned here.
   tree <- graph_battery[[which(vapply(graph_battery, function(c) numadmix(c$g) == 0, logical(1)))[1]]]$g
   wi <- admixtools:::graph_to_weightind(tree)
   expect_equal(nrow(wi[[1]]), 0L)
   expect_equal(nrow(wi[[2]]), 0L)
-  expect_identical(colnames(wi[[1]]),
-                   c('path', 'edge', 'edge2', 'leaf', 'leaf2', 'numpaths', 'cnt', 'keep'))
+  expect_identical(colnames(wi[[1]]), c('path', 'edge2', 'leaf2'))
   expect_identical(colnames(wi[[2]]), c('path', 'admixedge'))
   expect_type(wi[[3]], 'integer')
 })


### PR DESCRIPTION
A small follow up to #167, which rewrote these tables in base R but kept the original column layout to stay byte identical.

## Summary

`graph_to_weightind` returns `path_edge_table` with eight columns (`path`, `edge`, `edge2`, `leaf`, `leaf2`, `numpaths`, `cnt`, `keep`), but only three are ever read. This emits just those three.

The eight column shape is a byproduct of the original dplyr pipeline, which ended in `as.matrix` on the full grouped tibble and so materialized every intermediate value the computation happened to produce. The base R rewrite in #167 reproduced that shape verbatim to stay byte identical. This change drops the five columns nothing consumes.

## Why these columns are dead, not a stub

* `cpp_fill_pwts` reads `path`, `edge2` and `leaf2` by position. The previous C++ implementation, still present commented out, reads the same three. No version ever read the others.
* The R fallback `fill_pwts` reads the same three by name.
* A search of the package R code, C++, tests, and vignettes finds no other reader of `edge`, `leaf`, `numpaths`, `cnt`, or `keep` from this table.
* `graph_to_weightind` is internal, so there is no documented column contract for callers to depend on. The four remaining intermediates still exist as locals to compute the keep mask, so nothing becomes harder to revive if it is ever wanted.

## Change

* R: build `path_edge_table` as `cbind(path, edge2, leaf2)` filtered by the keep mask.
* C++: `cpp_fill_pwts` reads `edge2` and `leaf2` from columns 1 and 2 instead of 2 and 4.
* Drop the now unreachable empty edge guard and the zero row storage mode fixup, which only mirrored the old `as.matrix` behaviour for a zero admixture graph, a case `qpgraph` never routes here.
* The contract test that pinned the column set is updated to the three column shape.

## Correctness

Output is unchanged. `qpgraph` score, edge weights, and f3 statistics, and `find_graphs` winners and scores, are byte identical to #167 across the simulated cases and seeds. This is a layout change to an internal intermediate, not a change to any computed value.

This is a cleanup. It does not target a measurable speed or memory gain; the table is small and built once per graph, so removing columns from it does not move allocation or wall time appreciably. The value is a smaller, explicit column contract between the R helper and the C++ consumer.
