### PR TITLE
feat: warn at attach when R is using the reference BLAS

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,78 @@
+# BLAS backend check. The qpgraph optimizer and the f-statistic kernels are
+# dominated by dense linear algebra, so the BLAS that R is linked against
+# matters a lot: R's bundled reference (netlib) BLAS is commonly ten times
+# slower or more than an optimized BLAS such as OpenBLAS, MKL, or Accelerate on
+# macOS. Stock R on some platforms (notably the default macOS CRAN build) ships
+# the reference BLAS, so users can be paying that cost without knowing it. We
+# emit a one time, suppressible note at attach so the choice is at least visible.
+
+# TRUE if the path names a known optimized BLAS. Pure and string only so it can
+# be tested directly. Tokens are the distinctive part of each vendor's real
+# library filename (after symlink resolution); anything not recognized is
+# treated as possibly the reference BLAS. Tokens are anchored where a bare word
+# would collide: libmkl/mkl_rt not 'mkl', libgoto not 'goto', libsci_ not
+# 'libsci' (vs libscience), blas_sequential/blas_openmp not bare libblas (vs
+# NEC), accelerate/veclib path components not the generic libBLAS basename.
+blas_looks_optimized = function(path) {
+  grepl(paste0(
+    'openblas|libmkl|mkl_rt|',            # OpenBLAS, Intel MKL
+    'libblis|blis-|aoclblas|',            # AMD AOCL / BLIS (Flame)
+    'lib[ts]?atlas|atlas/|libgoto|',      # ATLAS, GotoBLAS
+    'accelerate\\.framework|veclib|',     # Apple Accelerate / vecLib
+    'libsci_|libessl|armpl|',             # Cray LibSci, IBM ESSL, Arm PL
+    'nvpl|nvblas|',                       # NVIDIA NVPL, NVBLAS
+    'fjlapack|libfj|',                    # Fujitsu SSL2 / A64FX
+    'blas_sequential|blas_openmp|',       # NEC NLC (SX-Aurora)
+    'sunperf|',                           # Oracle/Sun Performance Library
+    'flexiblas'),                         # FlexiBLAS dispatcher (see classify_blas)
+    path, ignore.case = TRUE)
+}
+
+# a usable library path, as opposed to a bare version string or empty/NA
+is_blas_path = function(x) {
+  length(x) == 1L && !is.na(x) && nzchar(x) &&
+    grepl('[/\\\\]|\\.(so|dylib|dll|framework)', x)
+}
+
+# Classify a single BLAS library path: TRUE reference, FALSE optimized, NA if
+# it is not a usable path. Symlinks are resolved first because both Debian's
+# update-alternatives and the common macOS recipe of linking libRblas at
+# Accelerate point a generic name at the real library, so the optimized backend
+# is only visible once the link is followed.
+classify_blas = function(path) {
+  if(!is_blas_path(path)) return(NA)
+  path = tryCatch(normalizePath(path, mustWork = FALSE), error = function(e) path)
+  if(!blas_looks_optimized(path)) return(TRUE)
+  # FlexiBLAS dispatches to a backend at runtime, so a path naming flexiblas
+  # does not guarantee a fast backend. Its distro default is optimized (Fedora
+  # and openSUSE ship OpenBLAS as the default), but an explicit FLEXIBLAS env
+  # override to the reference backend means the active BLAS really is slow.
+  if(grepl('flexiblas', path, ignore.case = TRUE)) {
+    fb = Sys.getenv('FLEXIBLAS')
+    if(nzchar(fb) && grepl('netlib|reference', fb, ignore.case = TRUE)) return(TRUE)
+  }
+  FALSE
+}
+
+# TRUE if R's BLAS looks like the reference BLAS, FALSE if optimized, NA if R
+# reports no usable path (e.g. some Windows builds). extSoftVersion() is light
+# and reports the path on modern R; sessionInfo() is the heavier fallback.
+blas_is_reference = function() {
+  path = tryCatch(extSoftVersion()[['BLAS']], error = function(e) '')
+  if(!is_blas_path(path)) path = tryCatch(utils::sessionInfo()$BLAS, error = function(e) '')
+  classify_blas(path)
+}
+
+.onAttach = function(libname, pkgname) {
+  if(isFALSE(getOption('admixtools.blas_check'))) return(invisible())
+  # an advisory note must never be able to block the package from loading
+  if(isTRUE(tryCatch(blas_is_reference(), error = function(e) NA)))
+    packageStartupMessage(
+      'admixtools does heavy dense linear algebra (qpgraph and the f-statistic ',
+      'kernels) and runs much faster with an optimized BLAS such as OpenBLAS, ',
+      'MKL, or Accelerate on macOS.\n',
+      'R appears to be using its reference BLAS, which is commonly 10x or more ',
+      'slower. See vignette("parallel", package = "admixtools") for how to ',
+      'check and switch your BLAS. Set options(admixtools.blas_check = FALSE) ',
+      'to silence this note.')
+}

--- a/tests/testthat/test-blas-check.R
+++ b/tests/testthat/test-blas-check.R
@@ -1,0 +1,100 @@
+# Tests for the attach-time BLAS note (R/zzz.R). The classification is a pure
+# string function so it can be checked against real library paths from each
+# platform without depending on the BLAS the test machine happens to use.
+
+test_that("blas_looks_optimized recognizes optimized backends across vendors", {
+  optimized <- c(
+    "/opt/homebrew/Cellar/openblas/0.3.33/lib/libopenblasp-r0.3.33.dylib",   # OpenBLAS (Homebrew)
+    "/usr/lib/x86_64-linux-gnu/openblas-pthread/libblas.so.3",               # OpenBLAS (Debian alt)
+    "/opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_rt.so.2",               # Intel MKL
+    "/usr/lib/x86_64-linux-gnu/blis-openmp/libblis.so.4",                    # BLIS / AMD AOCL
+    "/usr/lib/x86_64-linux-gnu/atlas/libblas.so.3",                          # ATLAS (Debian)
+    "/usr/lib/libtatlas.so.3",                                               # ATLAS (threaded)
+    "/usr/lib/libsatlas.so.3",                                               # ATLAS (serial)
+    "/opt/openblas/lib/libgoto2_haswellp-r1.13.so",                          # GotoBLAS2
+    "/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/libBLAS.dylib", # Apple Accelerate
+    "/opt/cray/pe/libsci/23.09/GNU/12.3/x86_64/lib/libsci_gnu_82_mp.so",     # Cray LibSci
+    "/opt/ibm/essl/lib64/libesslsmp.so.1",                                   # IBM ESSL
+    "/opt/arm/armpl/lib/libarmpl_lp64_mp.so",                                # Arm Performance Libraries
+    "/usr/lib/nvpl/lib/libnvpl_blas_lp64_gomp.so.0",                         # NVIDIA NVPL
+    "/usr/lib/libnvblas.so.12",                                              # NVBLAS (GPU interposer)
+    "/opt/FJSVxos/lib64/libfjlapackexsve_lp64.so",                           # Fujitsu A64FX SSL2
+    "/opt/nec/ve/nlc/lib/libblas_openmp.so",                                 # NEC NLC
+    "/opt/oracle/lib/libsunperf.so.5",                                       # Oracle/Sun Performance
+    "/usr/lib64/libflexiblas.so.3")                                          # FlexiBLAS dispatcher
+  for (p in optimized) expect_true(admixtools:::blas_looks_optimized(p), info = p)
+})
+
+test_that("blas_looks_optimized does not recognize the reference BLAS", {
+  reference <- c(
+    "/Library/Frameworks/R.framework/Resources/lib/libRblas.dylib",   # macOS CRAN default
+    "/usr/lib/R/lib/libRblas.so",
+    "/usr/lib/x86_64-linux-gnu/blas/libblas.so.3",                    # Debian netlib reference
+    "/usr/lib64/blas/reference/libblas.so.3")                         # generic netlib reference
+  for (p in reference) expect_false(admixtools:::blas_looks_optimized(p), info = p)
+})
+
+test_that("a reference BLAS under a vendor-named parent directory is not misclassified", {
+  # the optimized tokens are anchored so a coincidental directory or user name
+  # does not suppress the note for a real reference BLAS
+  tricky <- c(
+    "/opt/atlassian/R/lib/libRblas.so",      # 'atlas' inside 'atlassian'
+    "/home/dessler/R/lib/libRblas.so",       # 'essl' inside 'dessler'
+    "/home/bliss/R/lib/libRblas.so",         # 'blis' inside 'bliss'
+    "/srv/accelerate-team/lib/libRblas.so",  # 'accelerate' without '.framework'
+    "/opt/libscience/lib/libRblas.so")       # 'libsci' inside 'libscience'
+  for (p in tricky) expect_false(admixtools:::blas_looks_optimized(p), info = p)
+})
+
+test_that("classify_blas honors the FLEXIBLAS backend override", {
+  fb_path <- "/usr/lib64/libflexiblas.so.3"
+  old <- Sys.getenv("FLEXIBLAS", unset = NA)
+  on.exit(if (is.na(old)) Sys.unsetenv("FLEXIBLAS") else Sys.setenv(FLEXIBLAS = old), add = TRUE)
+  Sys.unsetenv("FLEXIBLAS")
+  expect_false(admixtools:::classify_blas(fb_path))            # distro default, treat as optimized
+  Sys.setenv(FLEXIBLAS = "netlib")
+  expect_true(admixtools:::classify_blas(fb_path))             # explicit reference backend
+  Sys.setenv(FLEXIBLAS = "openblas")
+  expect_false(admixtools:::classify_blas(fb_path))            # explicit fast backend
+})
+
+test_that("classify_blas follows a symlink to the real backend", {
+  # update-alternatives (Debian) and the macOS Accelerate recipe both expose the
+  # optimized library only through a symlink at a generic name, so classify_blas
+  # must resolve the link before deciding.
+  d <- tempfile("blas"); dir.create(d); on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  real <- file.path(d, "libopenblas.so.3"); file.create(real)
+  link <- file.path(d, "libRblas.so")
+  ok <- tryCatch(file.symlink(real, link), warning = function(w) FALSE, error = function(e) FALSE)
+  if (!isTRUE(ok)) skip("symlinks not available on this platform")
+  expect_false(admixtools:::classify_blas(link))   # resolves to libopenblas, not reference
+  ref <- file.path(d, "libRblas2.so"); file.create(ref)
+  expect_true(admixtools:::classify_blas(ref))      # a real file with no optimized name
+})
+
+test_that("classify_blas returns NA for input that is not a library path", {
+  for (x in list("", "3.11.0", NA_character_, character(0)))
+    expect_true(is.na(admixtools:::classify_blas(x)), info = paste(x, collapse = ","))
+})
+
+test_that("blas_is_reference returns a single logical or NA", {
+  v <- admixtools:::blas_is_reference()
+  expect_length(v, 1)
+  expect_true(is.logical(v))
+  expect_true(is.na(v) || v %in% c(TRUE, FALSE))
+})
+
+test_that("the attach note fires on a reference BLAS and is silenced by the option", {
+  # Drive both branches without depending on the test machine's BLAS.
+  testthat::local_mocked_bindings(blas_is_reference = function() TRUE, .package = "admixtools")
+  expect_message(admixtools:::.onAttach("lib", "admixtools"), "reference BLAS")
+
+  old <- options(admixtools.blas_check = FALSE)
+  on.exit(options(old), add = TRUE)
+  expect_message(admixtools:::.onAttach("lib", "admixtools"), NA)   # opted out, silent even on reference
+})
+
+test_that("the attach note stays silent on an optimized BLAS", {
+  testthat::local_mocked_bindings(blas_is_reference = function() FALSE, .package = "admixtools")
+  expect_message(admixtools:::.onAttach("lib", "admixtools"), NA)
+})

--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -99,6 +99,24 @@ By default the kernels size their thread team from `parallelly::availableCores()
 * **Lowering what `availableCores()` reports**, for example with `options(mc.cores = 8)` or the variables described in `?parallelly::availableCores`, or running under a plan with more workers, which divides the budget further.
 
 
+## The BLAS library
+
+Before reaching for more cores it is worth checking which BLAS library R is linked against, because it is often the single largest performance lever. The `qpgraph` optimizer and the f-statistic kernels are dominated by dense linear algebra, and that work is handed to whatever BLAS R was built with. R's bundled reference (netlib) BLAS is single threaded and unoptimized, and is commonly ten times slower or more than an optimized BLAS such as [OpenBLAS](https://www.openblas.net), Intel MKL, Apple Accelerate, or BLIS. On some platforms, notably the default macOS CRAN build, R ships with the reference BLAS, so it is easy to be paying this cost without realizing it.
+
+Check what you have with
+
+```{r, eval = FALSE}
+sessionInfo()$BLAS
+```
+
+If the path names or resolves to `libRblas` (R's bundle) or the generic netlib `libblas`, you are likely on the reference BLAS. A name alone is not always conclusive, because on Debian and Ubuntu the same `libblas.so.3` name is a symlink that points at whichever backend is selected, so the optimized library is only visible once the link is followed. To switch, install an optimized BLAS and point R at it. The mechanics depend on the platform.
+
+* **Linux (Debian and Ubuntu)**: install `libopenblas-dev` and select it with `update-alternatives --config libblas.so.3-x86_64-linux-gnu`. No reinstall of R is needed.
+* **macOS**: link R's BLAS to the system Accelerate framework. This overwrites R's bundled `libRblas.dylib`, so back it up first, for example `cp "$(R RHOME)/lib/libRblas.dylib" "$(R RHOME)/lib/libRblas.dylib.bak"` and then `ln -sf /System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/libBLAS.dylib "$(R RHOME)/lib/libRblas.dylib"`. A Homebrew OpenBLAS works too.
+* **Conda**: `conda install "libblas=*=*openblas"`.
+
+admixtools emits a one time note at attach time when it detects the reference BLAS. It resolves symlinks first and recognizes the common optimized backends, including the desktop ones above and the vendor HPC libraries (Cray LibSci, IBM ESSL, Arm Performance Libraries, NVIDIA NVPL, Fujitsu SSL2, NEC NLC), so a cluster build on an optimized BLAS is not flagged. Silence the note with `options(admixtools.blas_check = FALSE)` or `suppressPackageStartupMessages(library(admixtools))`.
+
 ## Parallelization on a compute cluster
 
 Sometimes it makes more sense to parallelize across compute nodes rather than across cores. This can be done either in the traditional way of writing an R script and submitting it many times in parallel as separate jobs, or interactively from within R again using the `furrr` / `future` framework. The interactive route is more complicated to set up than parallelization across cores.


### PR DESCRIPTION
## Summary

The `qpgraph` optimizer and the f-statistic kernels are dominated by dense linear algebra, which R hands to whatever BLAS it was built against. R's bundled reference (netlib) BLAS is single threaded and unoptimized, and is commonly ten times slower or more than an optimized BLAS such as OpenBLAS, MKL, Apple Accelerate, or BLIS. Some platforms ship the reference BLAS by default (the stock macOS CRAN build is the common one), so a user can be paying a large slowdown without any signal that it is happening. Nothing in the package surfaced this before.

This adds a one time note at attach time when the reference BLAS is detected, plus a vignette section on how to check and switch.

## What it does

A new `R/zzz.R` classifies R's BLAS from the library path that `sessionInfo()$BLAS` and `extSoftVersion()` report. If a known optimized backend is recognized in the path (openblas, mkl, accelerate, veclib, blis, atlas, flexiblas, and a few HPC libraries) it stays silent. If none is recognized it emits a single `packageStartupMessage` pointing at the parallel vignette. If R reports no usable path (some Windows builds) it stays silent rather than guess.

The note is informational, not a gate. A reference BLAS is a performance choice, and some environments such as locked down clusters cannot change it, so blocking would be wrong. It is silenced with `options(admixtools.blas_check = FALSE)` or the usual `suppressPackageStartupMessages(library(admixtools))`.

## Detection notes

Classification is by library path because that is what R exposes and it cleanly separates the common cases, including the two backends that share the generic `libblas.so.3` name on Debian and Ubuntu (the path carries `openblas` or `blas` in its directory). The failure modes are benign. An unrecognized but fast BLAS would get a suppressible note, and an oddly named reference build would get none. It does not attempt to detect a fast BLAS that has been switched to a slow mode at runtime, such as FlexiBLAS pointed at netlib.

## Tests and docs

`tests/testthat/test-blas-check.R` checks the path classifier against real reference and optimized library paths from Linux, macOS, and conda, and drives both branches of the attach hook with a mocked detector so the message and the opt out are covered without depending on the test machine's BLAS. The parallel vignette gains a BLAS section with the per platform steps to check and switch.

No new dependencies. The detection uses base and utils functions only.
